### PR TITLE
Enhance error handling in MongoDB initialization and exceptions. Intr…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fastapi-mongo-base"
-version = "1.1.13"
+version = "1.2.0"
 description = "A simple boilerplate application, including models and schemas and abstract router, for FastAPI with MongoDB"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/fastapi_mongo_base/core/app_factory.py
+++ b/src/fastapi_mongo_base/core/app_factory.py
@@ -64,10 +64,12 @@ async def lifespan(
             function()
 
     logging.info("Startup complete")
-    yield
-    if worker:
-        app.state.worker.cancel()
-    logging.info("Shutdown complete")
+    try:
+        yield
+    finally:
+        if worker:
+            app.state.worker.cancel()
+        logging.info("Shutdown complete")
 
 
 def setup_exception_handlers(
@@ -319,6 +321,7 @@ def configure_app(
             List of log lines as strings.
 
         """
+
         def read_logs() -> list[str]:
             with open(settings.get_log_config()["info_log_path"], "rb") as f:
                 last_100_lines = deque(f, maxlen=100)

--- a/src/fastapi_mongo_base/core/config.py
+++ b/src/fastapi_mongo_base/core/config.py
@@ -34,7 +34,7 @@ class Settings(metaclass=Singleton):
     @property
     def cors_origins(self) -> list[str]:
         """
-        Get CORS allowed origins as a list.
+        CORS allowed origins as a list.
 
         Returns:
             List of allowed origin URLs.

--- a/src/fastapi_mongo_base/core/config.py
+++ b/src/fastapi_mongo_base/core/config.py
@@ -54,6 +54,9 @@ class Settings(metaclass=Singleton):
     mongo_connect_timeout_ms: int = int(
         os.getenv("MONGO_CONNECT_TIMEOUT_MS", default="5000")
     )
+    exit_on_init_failure: bool = os.getenv(
+        "EXIT_ON_INIT_FAILURE", default="true"
+    ).lower() in ("true", "on", "1")
 
     @classmethod
     def get_coverage_dir(cls) -> str:

--- a/src/fastapi_mongo_base/core/db.py
+++ b/src/fastapi_mongo_base/core/db.py
@@ -4,6 +4,7 @@ import logging
 
 from beanie import init_beanie
 
+from fastapi_mongo_base.core.errors.db_errors import raise_from_pymongo_error
 from fastapi_mongo_base.models import BaseEntity
 from fastapi_mongo_base.utils import basic
 
@@ -25,17 +26,18 @@ async def init_mongo_db(settings: Settings | None = None) -> object:
 
     Raises:
         ImportError: If MongoDB client libraries are not installed.
-        MongoDBConnectionError: If MongoDB connection or initialization fails.
+        MongoDBError: If MongoDB connection or initialization fails.
 
     """
     try:
         from pymongo import AsyncMongoClient
-        from pymongo.errors import PyMongoError, ServerSelectionTimeoutError
+        from pymongo.errors import PyMongoError
     except ImportError:
         try:
             from motor.motor_asyncio import AsyncIOMotorClient
 
             AsyncMongoClient = AsyncIOMotorClient  # noqa: N806
+            from pymongo.errors import PyMongoError
         except ImportError as e:
             raise ImportError("MongoDB is not installed") from e
 
@@ -61,19 +63,13 @@ async def init_mongo_db(settings: Settings | None = None) -> object:
                 )
             ],
         )
-    except ServerSelectionTimeoutError as e:
-        logging.exception(
-            "MongoDB connection timeout at %s", settings.mongo_uri
-        )
-        raise SystemExit(1) from e
-
     except PyMongoError as e:
         logging.exception("MongoDB error at %s", settings.mongo_uri)
-        raise SystemExit(1) from e
+        raise_from_pymongo_error(e)
 
     except Exception as e:
         logging.exception("Unexpected failure initializing MongoDB")
-        raise SystemExit(1) from e
+        raise_from_pymongo_error(e)
 
     return db
 

--- a/src/fastapi_mongo_base/core/db.py
+++ b/src/fastapi_mongo_base/core/db.py
@@ -11,6 +11,13 @@ from fastapi_mongo_base.utils import basic
 from .config import Settings
 
 
+def _fail_mongo_init(exc: Exception, settings: Settings) -> None:
+    """Exit the process or raise a typed MongoDB error on init failure."""
+    if settings.exit_on_init_failure:
+        raise SystemExit(1) from exc
+    raise_from_pymongo_error(exc)
+
+
 async def init_mongo_db(settings: Settings | None = None) -> object:
     """
     Initialize MongoDB connection and Beanie ODM.
@@ -26,30 +33,35 @@ async def init_mongo_db(settings: Settings | None = None) -> object:
 
     Raises:
         ImportError: If MongoDB client libraries are not installed.
-        MongoDBError: If MongoDB connection or initialization fails.
+        SystemExit: If connection fails and ``exit_on_init_failure`` is enabled
+            (default; use in Docker so the container restarts until Mongo is up).
+        MongoDBConnectionError: If MongoDB connection or initialization fails
+            and ``exit_on_init_failure`` is disabled.
+        MongoDBConnectionTimeoutError: If MongoDB connection times out and
+            ``exit_on_init_failure`` is disabled.
 
     """
     try:
         from pymongo import AsyncMongoClient
-        from pymongo.errors import PyMongoError
+        from pymongo.errors import PyMongoError, ServerSelectionTimeoutError
     except ImportError:
         try:
             from motor.motor_asyncio import AsyncIOMotorClient
 
             AsyncMongoClient = AsyncIOMotorClient  # noqa: N806
-            from pymongo.errors import PyMongoError
+            from pymongo.errors import PyMongoError, ServerSelectionTimeoutError
         except ImportError as e:
             raise ImportError("MongoDB is not installed") from e
 
     if settings is None:
         settings = Settings()
 
-    client = AsyncMongoClient(
-        settings.mongo_uri,
-        serverSelectionTimeoutMS=settings.mongo_server_selection_timeout_ms,
-        connectTimeoutMS=settings.mongo_connect_timeout_ms,
-    )
     try:
+        client = AsyncMongoClient(
+            settings.mongo_uri,
+            serverSelectionTimeoutMS=settings.mongo_server_selection_timeout_ms,
+            connectTimeoutMS=settings.mongo_connect_timeout_ms,
+        )
         await client.server_info()
         db = client.get_database(settings.project_name)
         await init_beanie(
@@ -63,13 +75,19 @@ async def init_mongo_db(settings: Settings | None = None) -> object:
                 )
             ],
         )
+    except ServerSelectionTimeoutError as e:
+        logging.exception(
+            "MongoDB connection timeout at %s", settings.mongo_uri
+        )
+        _fail_mongo_init(e, settings)
+
     except PyMongoError as e:
         logging.exception("MongoDB error at %s", settings.mongo_uri)
-        raise_from_pymongo_error(e)
+        _fail_mongo_init(e, settings)
 
     except Exception as e:
         logging.exception("Unexpected failure initializing MongoDB")
-        raise_from_pymongo_error(e)
+        _fail_mongo_init(e, settings)
 
     return db
 
@@ -86,13 +104,13 @@ def init_redis(settings: Settings | None = None) -> tuple:
         Returns (None, None) if Redis is not configured or unavailable.
 
     """
+    if settings is None:
+        settings = Settings()
+
     try:
         from redis import Redis as RedisSync
         from redis.asyncio.client import Redis
         from redis.exceptions import RedisError
-
-        if settings is None:
-            settings = Settings()
 
         redis_uri = getattr(settings, "redis_uri", None)
         if redis_uri:
@@ -111,7 +129,8 @@ def init_redis(settings: Settings | None = None) -> tuple:
             return redis_sync, redis
     except RedisError as e:
         logging.exception("Redis connection error")
-        raise SystemExit(1) from e
+        if settings.exit_on_init_failure:
+            raise SystemExit(1) from e
     except (ImportError, AttributeError, Exception):
         logging.exception("Error initializing Redis")
 

--- a/src/fastapi_mongo_base/core/db.py
+++ b/src/fastapi_mongo_base/core/db.py
@@ -4,18 +4,11 @@ import logging
 
 from beanie import init_beanie
 
-from fastapi_mongo_base.core.errors.db_errors import raise_from_pymongo_error
+from fastapi_mongo_base.core.errors.db_errors import from_pymongo_error
 from fastapi_mongo_base.models import BaseEntity
 from fastapi_mongo_base.utils import basic
 
 from .config import Settings
-
-
-def _fail_mongo_init(exc: Exception, settings: Settings) -> None:
-    """Exit the process or raise a typed MongoDB error on init failure."""
-    if settings.exit_on_init_failure:
-        raise SystemExit(1) from exc
-    raise_from_pymongo_error(exc)
 
 
 async def init_mongo_db(settings: Settings | None = None) -> object:
@@ -33,8 +26,9 @@ async def init_mongo_db(settings: Settings | None = None) -> object:
 
     Raises:
         ImportError: If MongoDB client libraries are not installed.
-        SystemExit: If connection fails and ``exit_on_init_failure`` is enabled
-            (default; use in Docker so the container restarts until Mongo is up).
+        SystemExit: If connection fails and ``exit_on_init_failure`` is
+            enabled (default; use in Docker so the container restarts
+            until Mongo is up).
         MongoDBConnectionError: If MongoDB connection or initialization fails
             and ``exit_on_init_failure`` is disabled.
         MongoDBConnectionTimeoutError: If MongoDB connection times out and
@@ -43,13 +37,11 @@ async def init_mongo_db(settings: Settings | None = None) -> object:
     """
     try:
         from pymongo import AsyncMongoClient
-        from pymongo.errors import PyMongoError, ServerSelectionTimeoutError
     except ImportError:
         try:
             from motor.motor_asyncio import AsyncIOMotorClient
 
             AsyncMongoClient = AsyncIOMotorClient  # noqa: N806
-            from pymongo.errors import PyMongoError, ServerSelectionTimeoutError
         except ImportError as e:
             raise ImportError("MongoDB is not installed") from e
 
@@ -75,19 +67,11 @@ async def init_mongo_db(settings: Settings | None = None) -> object:
                 )
             ],
         )
-    except ServerSelectionTimeoutError as e:
-        logging.exception(
-            "MongoDB connection timeout at %s", settings.mongo_uri
-        )
-        _fail_mongo_init(e, settings)
-
-    except PyMongoError as e:
-        logging.exception("MongoDB error at %s", settings.mongo_uri)
-        _fail_mongo_init(e, settings)
-
     except Exception as e:
-        logging.exception("Unexpected failure initializing MongoDB")
-        _fail_mongo_init(e, settings)
+        logging.exception(
+            "MongoDB initialization failed at %s", settings.mongo_uri
+        )
+        raise from_pymongo_error(e, settings=settings) from e
 
     return db
 

--- a/src/fastapi_mongo_base/core/enums.py
+++ b/src/fastapi_mongo_base/core/enums.py
@@ -47,7 +47,7 @@ class Language(StrEnum):
     @property
     def _info(self) -> dict[str, str]:
         """
-        Get language information dictionary.
+        Language information dictionary.
 
         Returns:
             Dictionary containing Persian name, English name, and abbreviation.
@@ -174,7 +174,7 @@ class Language(StrEnum):
     @property
     def fa(self) -> str:
         """
-        Get Persian name of the language.
+        Persian name of the language.
 
         Returns:
             Persian name string.
@@ -185,7 +185,7 @@ class Language(StrEnum):
     @property
     def en(self) -> str:
         """
-        Get English name of the language.
+        English name of the language.
 
         Returns:
             English name string.
@@ -196,7 +196,7 @@ class Language(StrEnum):
     @property
     def abbreviation(self) -> str:
         """
-        Get language abbreviation code.
+        Language abbreviation code.
 
         Returns:
             Two-letter language code (e.g., "en", "fa").

--- a/src/fastapi_mongo_base/core/errors/db_errors.py
+++ b/src/fastapi_mongo_base/core/errors/db_errors.py
@@ -1,0 +1,718 @@
+"""MongoDB-related HTTP exceptions."""
+
+from typing import ClassVar
+
+from fastapi_mongo_base.core.errors.i18n import build_messages
+from fastapi_mongo_base.core.exceptions import BaseHTTPException
+
+
+class MongoDBError(BaseHTTPException):
+    """Base exception for all MongoDB-related errors."""
+
+    status_code: ClassVar[int] = 500
+    error_code: ClassVar[str] = "mongodb_error"
+    default_message: ClassVar[str] = "A database error occurred"
+    default_message_fa: ClassVar[str | None] = (
+        "مشکلی در پایگاه داده پیش آمد. لطفاً دوباره تلاش کنید."
+    )
+
+    def __init__(
+        self,
+        *,
+        detail: str | None = None,
+        message: dict | None = None,
+        **kwargs: object,
+    ) -> None:
+        super().__init__(
+            status_code=self.status_code,
+            error=self.error_code,
+            detail=detail,
+            message=message
+            or build_messages(self.default_message, self.default_message_fa),
+            **kwargs,
+        )
+
+
+class MongoDBConnectionError(MongoDBError):
+    """Raised when the application cannot establish a connection to MongoDB."""
+
+    status_code = 503
+    error_code = "mongodb_connection_error"
+    default_message = "Unable to connect to the database"
+    default_message_fa = (
+        "در حال حاضر امکان اتصال به پایگاه داده وجود ندارد. "
+        "لطفاً چند لحظه دیگر دوباره تلاش کنید."
+    )
+
+
+class MongoDBConnectionTimeoutError(MongoDBConnectionError):
+    """Raised when a MongoDB connection attempt times out."""
+
+    error_code = "mongodb_connection_timeout"
+    default_message = "Database connection timed out"
+    default_message_fa = (
+        "اتصال به پایگاه داده بیش از حد طول کشید. لطفاً دوباره تلاش کنید."
+    )
+
+
+class MongoDBOperationTimeoutError(MongoDBError):
+    """Raised when a MongoDB operation exceeds its time limit."""
+
+    status_code = 504
+    error_code = "mongodb_operation_timeout"
+    default_message = "Database operation timed out"
+    default_message_fa = (
+        "انجام این درخواست بیش از حد طول کشید. لطفاً دوباره تلاش کنید."
+    )
+
+
+class DocumentNotFoundError(MongoDBError):
+    """Raised when a requested document does not exist."""
+
+    status_code = 404
+    error_code = "document_not_found"
+    default_message = "Document not found"
+    default_message_fa = "موردی با این مشخصات پیدا نشد."
+
+    def __init__(
+        self,
+        *,
+        collection: str | None = None,
+        uid: str | None = None,
+        detail: str | None = None,
+        message: dict | None = None,
+        **kwargs: object,
+    ) -> None:
+        if message is None:
+            if collection and uid:
+                message = build_messages(
+                    f"Document not found in '{collection}' with id '{uid}'",
+                    f"در «{collection}» موردی با شناسه «{uid}» پیدا نشد.",
+                )
+            elif collection:
+                message = build_messages(
+                    f"Document not found in '{collection}'",
+                    f"در «{collection}» موردی پیدا نشد.",
+                )
+            elif uid:
+                message = build_messages(
+                    f"Document with id '{uid}' not found",
+                    f"موردی با شناسه «{uid}» پیدا نشد.",
+                )
+            else:
+                message = build_messages(
+                    self.default_message,
+                    self.default_message_fa,
+                )
+        super().__init__(
+            detail=detail,
+            message=message,
+            collection=collection,
+            uid=uid,
+            **kwargs,
+        )
+
+
+class DocumentAlreadyExistsError(MongoDBError):
+    """Raised when creating a document that already exists."""
+
+    status_code = 409
+    error_code = "document_already_exists"
+    default_message = "Document already exists"
+    default_message_fa = "این مورد از قبل ثبت شده است."
+
+    def __init__(
+        self,
+        *,
+        collection: str | None = None,
+        uid: str | None = None,
+        detail: str | None = None,
+        message: dict | None = None,
+        **kwargs: object,
+    ) -> None:
+        if message is None:
+            if collection and uid:
+                message = build_messages(
+                    f"Document already exists in '{collection}' with id '{uid}'",
+                    f"در «{collection}» موردی با شناسه «{uid}» از قبل ثبت شده است.",
+                )
+            elif collection:
+                message = build_messages(
+                    f"Document already exists in '{collection}'",
+                    f"در «{collection}» این مورد از قبل وجود دارد.",
+                )
+            else:
+                message = build_messages(
+                    self.default_message,
+                    self.default_message_fa,
+                )
+        super().__init__(
+            detail=detail,
+            message=message,
+            collection=collection,
+            uid=uid,
+            **kwargs,
+        )
+
+
+class DuplicateKeyError(MongoDBError):
+    """Raised on unique-index constraint violations (MongoDB error code 11000)."""
+
+    status_code = 409
+    error_code = "duplicate_key"
+    default_message = "A record with this value already exists"
+    default_message_fa = (
+        "این مقدار قبلاً ثبت شده است. لطفاً مقدار دیگری وارد کنید."
+    )
+
+    def __init__(
+        self,
+        *,
+        field: str | None = None,
+        value: str | None = None,
+        collection: str | None = None,
+        detail: str | None = None,
+        message: dict | None = None,
+        **kwargs: object,
+    ) -> None:
+        if message is None:
+            if field and value:
+                message = build_messages(
+                    f"A record with {field}='{value}' already exists",
+                    f"مقدار {field}='{value}' قبلاً ثبت شده است.",
+                )
+            elif field:
+                message = build_messages(
+                    f"A record with this {field} already exists",
+                    f"این {field} قبلاً ثبت شده است. لطفاً مقدار دیگری وارد کنید.",
+                )
+            else:
+                message = build_messages(
+                    self.default_message,
+                    self.default_message_fa,
+                )
+        super().__init__(
+            detail=detail,
+            message=message,
+            field=field,
+            value=value,
+            collection=collection,
+            **kwargs,
+        )
+
+
+class MultipleDocumentsFoundError(MongoDBError):
+    """Raised when a query expected a single document but found several."""
+
+    status_code = 409
+    error_code = "multiple_documents_found"
+    default_message = "Multiple documents matched the query"
+    default_message_fa = (
+        "بیش از یک نتیجه پیدا شد. لطفاً جستجوی دقیق‌تری انجام دهید."
+    )
+
+    def __init__(
+        self,
+        *,
+        collection: str | None = None,
+        count: int | None = None,
+        detail: str | None = None,
+        message: dict | None = None,
+        **kwargs: object,
+    ) -> None:
+        if message is None:
+            if collection and count is not None:
+                message = build_messages(
+                    f"Expected a single document in '{collection}', "
+                    f"but found {count}",
+                    f"در «{collection}» باید یک نتیجه می‌یافت، "
+                    f"اما {count} مورد پیدا شد.",
+                )
+            elif collection:
+                message = build_messages(
+                    f"Expected a single document in '{collection}', "
+                    "but found multiple",
+                    f"در «{collection}» باید یک نتیجه می‌یافت، "
+                    "اما چند مورد پیدا شد.",
+                )
+            else:
+                message = build_messages(
+                    self.default_message,
+                    self.default_message_fa,
+                )
+        super().__init__(
+            detail=detail,
+            message=message,
+            collection=collection,
+            count=count,
+            **kwargs,
+        )
+
+
+class DocumentValidationError(MongoDBError):
+    """Raised when a document fails schema or field validation before save."""
+
+    status_code = 422
+    error_code = "document_validation_error"
+    default_message = "Document validation failed"
+    default_message_fa = "اطلاعات وارد شده معتبر نیست."
+
+    def __init__(
+        self,
+        *,
+        field: str | None = None,
+        reason: str | None = None,
+        detail: str | None = None,
+        message: dict | None = None,
+        **kwargs: object,
+    ) -> None:
+        if message is None:
+            if field and reason:
+                message = build_messages(
+                    f"Validation failed for field '{field}': {reason}",
+                    f"مقدار «{field}» معتبر نیست: {reason}",
+                )
+            elif field:
+                message = build_messages(
+                    f"Validation failed for field '{field}'",
+                    f"لطفاً مقدار «{field}» را بررسی و اصلاح کنید.",
+                )
+            else:
+                message = build_messages(
+                    self.default_message,
+                    self.default_message_fa,
+                )
+        super().__init__(
+            detail=detail,
+            message=message,
+            field=field,
+            reason=reason,
+            **kwargs,
+        )
+
+
+class InvalidObjectIdError(MongoDBError):
+    """Raised when an identifier is not a valid MongoDB ObjectId."""
+
+    status_code = 400
+    error_code = "invalid_object_id"
+    default_message = "Invalid document identifier"
+    default_message_fa = "شناسه وارد شده معتبر نیست."
+
+    def __init__(
+        self,
+        *,
+        value: str | None = None,
+        detail: str | None = None,
+        message: dict | None = None,
+        **kwargs: object,
+    ) -> None:
+        if message is None:
+            if value:
+                message = build_messages(
+                    f"Invalid document identifier: '{value}'",
+                    f"شناسه «{value}» معتبر نیست. لطفاً شناسه را بررسی کنید.",
+                )
+            else:
+                message = build_messages(
+                    self.default_message,
+                    self.default_message_fa,
+                )
+        super().__init__(
+            detail=detail,
+            message=message,
+            value=value,
+            **kwargs,
+        )
+
+
+class InvalidQueryError(MongoDBError):
+    """Raised when a query filter or aggregation pipeline is malformed."""
+
+    status_code = 400
+    error_code = "invalid_query"
+    default_message = "Invalid database query"
+    default_message_fa = "درخواست ارسالی معتبر نیست."
+
+    def __init__(
+        self,
+        *,
+        reason: str | None = None,
+        detail: str | None = None,
+        message: dict | None = None,
+        **kwargs: object,
+    ) -> None:
+        if message is None:
+            if reason:
+                message = build_messages(reason, reason)
+            else:
+                message = build_messages(
+                    self.default_message,
+                    self.default_message_fa,
+                )
+        super().__init__(
+            detail=detail,
+            message=message,
+            reason=reason,
+            **kwargs,
+        )
+
+
+class MongoDBReadError(MongoDBError):
+    """Raised when a read operation fails unexpectedly."""
+
+    error_code = "mongodb_read_error"
+    default_message = "Failed to read from the database"
+    default_message_fa = (
+        "خواندن اطلاعات با مشکل مواجه شد. لطفاً دوباره تلاش کنید."
+    )
+
+
+class MongoDBWriteError(MongoDBError):
+    """Raised when a write operation fails unexpectedly."""
+
+    error_code = "mongodb_write_error"
+    default_message = "Failed to write to the database"
+    default_message_fa = (
+        "ذخیره اطلاعات با مشکل مواجه شد. لطفاً دوباره تلاش کنید."
+    )
+
+
+class BulkWriteError(MongoDBError):
+    """Raised when a bulk write operation has one or more failures."""
+
+    status_code = 400
+    error_code = "bulk_write_error"
+    default_message = "Bulk write operation failed"
+    default_message_fa = (
+        "ذخیره گروهی اطلاعات کامل نشد. لطفاً دوباره تلاش کنید."
+    )
+
+    def __init__(
+        self,
+        *,
+        failed_count: int | None = None,
+        detail: str | None = None,
+        message: dict | None = None,
+        **kwargs: object,
+    ) -> None:
+        if message is None:
+            if failed_count is not None:
+                message = build_messages(
+                    f"Bulk write failed for {failed_count} document(s)",
+                    f"ذخیره {failed_count} مورد با مشکل مواجه شد.",
+                )
+            else:
+                message = build_messages(
+                    self.default_message,
+                    self.default_message_fa,
+                )
+        super().__init__(
+            detail=detail,
+            message=message,
+            failed_count=failed_count,
+            **kwargs,
+        )
+
+
+class TransactionError(MongoDBError):
+    """Raised when a multi-document transaction is aborted or cannot commit."""
+
+    error_code = "transaction_error"
+    default_message = "Database transaction failed"
+    default_message_fa = (
+        "این عملیات کامل نشد. لطفاً دوباره تلاش کنید."
+    )
+
+
+class WriteConflictError(MongoDBError):
+    """Raised on optimistic-concurrency or write-conflict errors."""
+
+    status_code = 409
+    error_code = "write_conflict"
+    default_message = (
+        "The document was modified by another request. "
+        "Please retry with the latest version"
+    )
+    default_message_fa = (
+        "این مورد هم‌زمان توسط درخواست دیگری تغییر کرده است. "
+        "لطفاً صفحه را به‌روزرسانی کنید و دوباره تلاش کنید."
+    )
+
+
+class UnauthorizedDatabaseAccessError(MongoDBError):
+    """Raised when the database user lacks permission for the requested action."""
+
+    status_code = 403
+    error_code = "unauthorized_database_access"
+    default_message = "Insufficient database permissions"
+    default_message_fa = "شما دسترسی لازم برای این عملیات را ندارید."
+
+
+class MongoDBIndexError(MongoDBError):
+    """Raised when index creation or management fails."""
+
+    error_code = "mongodb_index_error"
+    default_message = "Database index operation failed"
+    default_message_fa = (
+        "مشکلی در به‌روزرسانی فهرست جستجو پیش آمد. لطفاً دوباره تلاش کنید."
+    )
+
+    def __init__(
+        self,
+        *,
+        index: str | None = None,
+        collection: str | None = None,
+        detail: str | None = None,
+        message: dict | None = None,
+        **kwargs: object,
+    ) -> None:
+        if message is None:
+            if collection and index:
+                message = build_messages(
+                    f"Failed to manage index '{index}' on collection '{collection}'",
+                    f"به‌روزرسانی فهرست «{index}» در «{collection}» انجام نشد.",
+                )
+            elif index:
+                message = build_messages(
+                    f"Failed to manage index '{index}'",
+                    f"به‌روزرسانی فهرست «{index}» انجام نشد.",
+                )
+            else:
+                message = build_messages(
+                    self.default_message,
+                    self.default_message_fa,
+                )
+        super().__init__(
+            detail=detail,
+            message=message,
+            index=index,
+            collection=collection,
+            **kwargs,
+        )
+
+
+def _duplicate_key_from_details(
+    details: dict,
+    *,
+    detail: str | None = None,
+) -> DuplicateKeyError:
+    key_pattern = details.get("keyPattern") or {}
+    key_value = details.get("keyValue") or {}
+    field = next(iter(key_pattern), None)
+    value = str(key_value[field]) if field and field in key_value else None
+    return DuplicateKeyError(field=field, value=value, detail=detail)
+
+
+def _map_connection_error(exc: Exception, detail: str) -> MongoDBError | None:
+    from pymongo.errors import (
+        ConfigurationError,
+        ConnectionFailure,
+        InvalidURI,
+        NetworkTimeout,
+        ServerSelectionTimeoutError,
+        WaitQueueTimeoutError,
+    )
+
+    if isinstance(
+        exc,
+        (ServerSelectionTimeoutError, NetworkTimeout, WaitQueueTimeoutError),
+    ):
+        return MongoDBConnectionTimeoutError(detail=detail)
+    if isinstance(exc, (ConnectionFailure, InvalidURI, ConfigurationError)):
+        return MongoDBConnectionError(detail=detail)
+    return None
+
+
+def _map_write_error(exc: Exception, detail: str) -> MongoDBError | None:
+    from pymongo.errors import (
+        BulkWriteError as PyMongoBulkWriteError,
+        DuplicateKeyError as PyMongoDuplicateKeyError,
+        WriteConcernError,
+        WriteError,
+        WTimeoutError,
+    )
+
+    if isinstance(exc, PyMongoDuplicateKeyError):
+        return _duplicate_key_from_details(
+            getattr(exc, "details", {}) or {},
+            detail=detail,
+        )
+    if isinstance(exc, PyMongoBulkWriteError):
+        write_errors = (getattr(exc, "details", {}) or {}).get(
+            "writeErrors", []
+        )
+        if len(write_errors) == 1 and write_errors[0].get("code") in (
+            11000,
+            11001,
+        ):
+            return _duplicate_key_from_details(write_errors[0], detail=detail)
+        return BulkWriteError(
+            failed_count=len(write_errors),
+            detail=detail,
+        )
+    if isinstance(exc, WTimeoutError):
+        return WriteConflictError(detail=detail)
+    if isinstance(exc, WriteConcernError):
+        return MongoDBWriteError(detail=detail)
+    if isinstance(exc, WriteError):
+        if getattr(exc, "code", None) in (11000, 11001):
+            return _duplicate_key_from_details(
+                getattr(exc, "details", {}) or {},
+                detail=detail,
+            )
+        return MongoDBWriteError(detail=detail)
+    return None
+
+
+def _map_server_error_code(exc: Exception, detail: str) -> MongoDBError | None:
+    from pymongo.errors import OperationFailure
+
+    if not isinstance(exc, OperationFailure):
+        return None
+
+    code = getattr(exc, "code", None)
+    if code in (13, 18):
+        return UnauthorizedDatabaseAccessError(detail=detail, reason=detail)
+    if code in (11000, 11001):
+        return _duplicate_key_from_details(
+            getattr(exc, "details", {}) or {},
+            detail=detail,
+        )
+    if code == 112:
+        return WriteConflictError(detail=detail)
+    if code == 50:
+        return MongoDBOperationTimeoutError(detail=detail)
+    if code == 121:
+        return DocumentValidationError(reason=detail, detail=detail)
+    return MongoDBError(detail=detail)
+
+
+def _map_operation_failure(exc: Exception, detail: str) -> MongoDBError | None:
+    from pymongo.errors import (
+        CursorNotFound,
+        DocumentTooLarge,
+        ExecutionTimeout,
+        InvalidDocument,
+        InvalidName,
+        InvalidOperation,
+    )
+
+    if isinstance(exc, ExecutionTimeout):
+        return MongoDBOperationTimeoutError(detail=detail)
+
+    mapped = _map_server_error_code(exc, detail)
+    if mapped is not None:
+        return mapped
+
+    if isinstance(exc, (InvalidDocument, DocumentTooLarge)):
+        return DocumentValidationError(reason=detail, detail=detail)
+    if isinstance(exc, (InvalidName, InvalidOperation)):
+        return InvalidQueryError(reason=detail, detail=detail)
+    if isinstance(exc, CursorNotFound):
+        return MongoDBReadError(detail=detail)
+    return None
+
+
+def find_driver_error(
+    exc: BaseException | None,
+    *,
+    _seen: set[int] | None = None,
+) -> BaseException | None:
+    """
+    Find a pymongo or BSON driver error in exc or its cause/context chain.
+
+    Returns None when exc is already a MongoDBError or no driver error exists.
+    """
+    if exc is None:
+        return None
+    if _seen is None:
+        _seen = set()
+    exc_id = id(exc)
+    if exc_id in _seen:
+        return None
+    _seen.add(exc_id)
+
+    if isinstance(exc, MongoDBError):
+        return None
+
+    try:
+        from bson.errors import InvalidId
+
+        if isinstance(exc, InvalidId):
+            return exc
+    except ImportError:
+        pass
+
+    try:
+        from pymongo.errors import PyMongoError
+
+        if isinstance(exc, PyMongoError):
+            return exc
+    except ImportError:
+        pass
+
+    for link in (exc.__cause__, exc.__context__):
+        found = find_driver_error(link, _seen=_seen)
+        if found is not None:
+            return found
+    return None
+
+
+def from_any_exception(exc: Exception) -> MongoDBError | None:
+    """
+    Convert exc or a wrapped driver error into a MongoDBError subclass.
+
+    Returns the exc unchanged when it is already MongoDBError, or None when
+    exc is unrelated to MongoDB.
+    """
+    if isinstance(exc, MongoDBError):
+        return exc
+    driver = find_driver_error(exc)
+    if driver is None:
+        return None
+    return from_pymongo_error(driver)
+
+
+def from_pymongo_error(exc: Exception) -> MongoDBError:
+    """
+    Convert a pymongo/BSON driver error into a MongoDBError subclass.
+
+    Check order matters: connection → write → operation failures.
+    """
+    detail = str(exc)
+
+    try:
+        from bson.errors import InvalidId
+
+        if isinstance(exc, InvalidId):
+            return InvalidObjectIdError(value=detail, detail=detail)
+    except ImportError:
+        pass
+
+    try:
+        from pymongo.errors import PyMongoError
+    except ImportError:
+        return MongoDBError(detail=detail)
+
+    if not isinstance(exc, PyMongoError):
+        return MongoDBError(detail=detail)
+
+    for mapper in (
+        _map_connection_error,
+        _map_write_error,
+        _map_operation_failure,
+    ):
+        mapped = mapper(exc, detail)
+        if mapped is not None:
+            return mapped
+
+    return MongoDBError(detail=detail)
+
+
+def raise_from_pymongo_error(exc: Exception) -> None:
+    """Re-raise a driver error as MongoDBError, keeping the original traceback."""
+    if isinstance(exc, MongoDBError):
+        raise exc
+    driver = find_driver_error(exc) or exc
+    raise from_pymongo_error(driver) from exc

--- a/src/fastapi_mongo_base/core/errors/db_errors.py
+++ b/src/fastapi_mongo_base/core/errors/db_errors.py
@@ -2,6 +2,7 @@
 
 from typing import ClassVar
 
+from fastapi_mongo_base.core.config import Settings
 from fastapi_mongo_base.core.errors.i18n import build_messages
 from fastapi_mongo_base.core.exceptions import BaseHTTPException
 
@@ -23,6 +24,7 @@ class MongoDBError(BaseHTTPException):
         message: dict | None = None,
         **kwargs: object,
     ) -> None:
+        """Initialize with optional detail, message, and extra context."""
         super().__init__(
             status_code=self.status_code,
             error=self.error_code,
@@ -83,6 +85,7 @@ class DocumentNotFoundError(MongoDBError):
         message: dict | None = None,
         **kwargs: object,
     ) -> None:
+        """Initialize with optional context fields and message overrides."""
         if message is None:
             if collection and uid:
                 message = build_messages(
@@ -130,11 +133,18 @@ class DocumentAlreadyExistsError(MongoDBError):
         message: dict | None = None,
         **kwargs: object,
     ) -> None:
+        """Initialize with optional context fields and message overrides."""
         if message is None:
             if collection and uid:
                 message = build_messages(
-                    f"Document already exists in '{collection}' with id '{uid}'",
-                    f"در «{collection}» موردی با شناسه «{uid}» از قبل ثبت شده است.",
+                    (
+                        f"Document already exists in '{collection}' "
+                        f"with id '{uid}'"
+                    ),
+                    (
+                        f"در «{collection}» موردی با شناسه «{uid}» "
+                        "از قبل ثبت شده است."
+                    ),
                 )
             elif collection:
                 message = build_messages(
@@ -156,7 +166,7 @@ class DocumentAlreadyExistsError(MongoDBError):
 
 
 class DuplicateKeyError(MongoDBError):
-    """Raised on unique-index constraint violations (MongoDB error code 11000)."""
+    """Raised on unique-index constraint violations (code 11000)."""
 
     status_code = 409
     error_code = "duplicate_key"
@@ -175,6 +185,7 @@ class DuplicateKeyError(MongoDBError):
         message: dict | None = None,
         **kwargs: object,
     ) -> None:
+        """Initialize with optional context fields and message overrides."""
         if message is None:
             if field and value:
                 message = build_messages(
@@ -184,7 +195,10 @@ class DuplicateKeyError(MongoDBError):
             elif field:
                 message = build_messages(
                     f"A record with this {field} already exists",
-                    f"این {field} قبلاً ثبت شده است. لطفاً مقدار دیگری وارد کنید.",
+                    (
+                        f"این {field} قبلاً ثبت شده است. "
+                        "لطفاً مقدار دیگری وارد کنید."
+                    ),
                 )
             else:
                 message = build_messages(
@@ -220,6 +234,7 @@ class MultipleDocumentsFoundError(MongoDBError):
         message: dict | None = None,
         **kwargs: object,
     ) -> None:
+        """Initialize with optional context fields and message overrides."""
         if message is None:
             if collection and count is not None:
                 message = build_messages(
@@ -266,6 +281,7 @@ class DocumentValidationError(MongoDBError):
         message: dict | None = None,
         **kwargs: object,
     ) -> None:
+        """Initialize with optional context fields and message overrides."""
         if message is None:
             if field and reason:
                 message = build_messages(
@@ -307,6 +323,7 @@ class InvalidObjectIdError(MongoDBError):
         message: dict | None = None,
         **kwargs: object,
     ) -> None:
+        """Initialize with optional context fields and message overrides."""
         if message is None:
             if value:
                 message = build_messages(
@@ -342,6 +359,7 @@ class InvalidQueryError(MongoDBError):
         message: dict | None = None,
         **kwargs: object,
     ) -> None:
+        """Initialize with optional context fields and message overrides."""
         if message is None:
             if reason:
                 message = build_messages(reason, reason)
@@ -384,9 +402,7 @@ class BulkWriteError(MongoDBError):
     status_code = 400
     error_code = "bulk_write_error"
     default_message = "Bulk write operation failed"
-    default_message_fa = (
-        "ذخیره گروهی اطلاعات کامل نشد. لطفاً دوباره تلاش کنید."
-    )
+    default_message_fa = "ذخیره گروهی اطلاعات کامل نشد. لطفاً دوباره تلاش کنید."
 
     def __init__(
         self,
@@ -396,6 +412,7 @@ class BulkWriteError(MongoDBError):
         message: dict | None = None,
         **kwargs: object,
     ) -> None:
+        """Initialize with optional context fields and message overrides."""
         if message is None:
             if failed_count is not None:
                 message = build_messages(
@@ -420,9 +437,7 @@ class TransactionError(MongoDBError):
 
     error_code = "transaction_error"
     default_message = "Database transaction failed"
-    default_message_fa = (
-        "این عملیات کامل نشد. لطفاً دوباره تلاش کنید."
-    )
+    default_message_fa = "این عملیات کامل نشد. لطفاً دوباره تلاش کنید."
 
 
 class WriteConflictError(MongoDBError):
@@ -441,7 +456,7 @@ class WriteConflictError(MongoDBError):
 
 
 class UnauthorizedDatabaseAccessError(MongoDBError):
-    """Raised when the database user lacks permission for the requested action."""
+    """Raised when the database user lacks permission for the action."""
 
     status_code = 403
     error_code = "unauthorized_database_access"
@@ -467,10 +482,14 @@ class MongoDBIndexError(MongoDBError):
         message: dict | None = None,
         **kwargs: object,
     ) -> None:
+        """Initialize with optional context fields and message overrides."""
         if message is None:
             if collection and index:
                 message = build_messages(
-                    f"Failed to manage index '{index}' on collection '{collection}'",
+                    (
+                        f"Failed to manage index '{index}' on "
+                        f"collection '{collection}'"
+                    ),
                     f"به‌روزرسانی فهرست «{index}» در «{collection}» انجام نشد.",
                 )
             elif index:
@@ -504,11 +523,38 @@ def _duplicate_key_from_details(
     return DuplicateKeyError(field=field, value=value, detail=detail)
 
 
+def _is_connection_error(exc: Exception) -> bool:
+    """Return True when exc indicates MongoDB is unreachable."""
+    try:
+        from pymongo.errors import (
+            ConfigurationError,
+            ConnectionFailure,
+            InvalidURI,
+            NetworkTimeout,
+            ServerSelectionTimeoutError,
+            WaitQueueTimeoutError,
+        )
+    except ImportError:
+        return False
+
+    return isinstance(
+        exc,
+        (
+            ServerSelectionTimeoutError,
+            NetworkTimeout,
+            WaitQueueTimeoutError,
+            ConnectionFailure,
+            InvalidURI,
+            ConfigurationError,
+        ),
+    )
+
+
 def _map_connection_error(exc: Exception, detail: str) -> MongoDBError | None:
+    if not _is_connection_error(exc):
+        return None
+
     from pymongo.errors import (
-        ConfigurationError,
-        ConnectionFailure,
-        InvalidURI,
         NetworkTimeout,
         ServerSelectionTimeoutError,
         WaitQueueTimeoutError,
@@ -519,15 +565,17 @@ def _map_connection_error(exc: Exception, detail: str) -> MongoDBError | None:
         (ServerSelectionTimeoutError, NetworkTimeout, WaitQueueTimeoutError),
     ):
         return MongoDBConnectionTimeoutError(detail=detail)
-    if isinstance(exc, (ConnectionFailure, InvalidURI, ConfigurationError)):
-        return MongoDBConnectionError(detail=detail)
-    return None
+    return MongoDBConnectionError(detail=detail)
 
 
 def _map_write_error(exc: Exception, detail: str) -> MongoDBError | None:
     from pymongo.errors import (
         BulkWriteError as PyMongoBulkWriteError,
+    )
+    from pymongo.errors import (
         DuplicateKeyError as PyMongoDuplicateKeyError,
+    )
+    from pymongo.errors import (
         WriteConcernError,
         WriteError,
         WTimeoutError,
@@ -614,6 +662,27 @@ def _map_operation_failure(exc: Exception, detail: str) -> MongoDBError | None:
     return None
 
 
+def _match_driver_error(exc: BaseException) -> BaseException | None:
+    """Return exc when it is a pymongo or BSON driver error."""
+    try:
+        from bson.errors import InvalidId
+
+        if isinstance(exc, InvalidId):
+            return exc
+    except ImportError:
+        pass
+
+    try:
+        from pymongo.errors import PyMongoError
+
+        if isinstance(exc, PyMongoError):
+            return exc
+    except ImportError:
+        pass
+
+    return None
+
+
 def find_driver_error(
     exc: BaseException | None,
     *,
@@ -636,21 +705,9 @@ def find_driver_error(
     if isinstance(exc, MongoDBError):
         return None
 
-    try:
-        from bson.errors import InvalidId
-
-        if isinstance(exc, InvalidId):
-            return exc
-    except ImportError:
-        pass
-
-    try:
-        from pymongo.errors import PyMongoError
-
-        if isinstance(exc, PyMongoError):
-            return exc
-    except ImportError:
-        pass
+    matched = _match_driver_error(exc)
+    if matched is not None:
+        return matched
 
     for link in (exc.__cause__, exc.__context__):
         found = find_driver_error(link, _seen=_seen)
@@ -674,11 +731,27 @@ def from_any_exception(exc: Exception) -> MongoDBError | None:
     return from_pymongo_error(driver)
 
 
-def from_pymongo_error(exc: Exception) -> MongoDBError:
+def _fail_mongo_init(exc: Exception, settings: Settings) -> None:
+    """Exit the process or raise a typed MongoDB error on init failure."""
+    if settings.exit_on_init_failure:
+        raise SystemExit(1) from exc
+    raise from_pymongo_error(exc, _for_raise=True) from exc
+
+
+def from_pymongo_error(
+    exc: Exception,
+    *,
+    settings: Settings | None = None,
+    _for_raise: bool = False,
+) -> MongoDBError:
     """
     Convert a pymongo/BSON driver error into a MongoDBError subclass.
 
     Check order matters: connection → write → operation failures.
+
+    When ``settings`` is provided and ``exc`` is a connection-health error,
+    delegates to :func:`_fail_mongo_init` so startup can exit or raise a typed
+    error. Non-pymongo exceptions are re-raised unchanged.
     """
     detail = str(exc)
 
@@ -695,14 +768,16 @@ def from_pymongo_error(exc: Exception) -> MongoDBError:
     except ImportError:
         return MongoDBError(detail=detail)
 
-    if not isinstance(exc, PyMongoError):
-        return MongoDBError(detail=detail)
+    connection_mapped = _map_connection_error(exc, detail)
+    if connection_mapped is not None:
+        if settings is not None and not _for_raise:
+            _fail_mongo_init(exc, settings)
+        return connection_mapped
 
-    for mapper in (
-        _map_connection_error,
-        _map_write_error,
-        _map_operation_failure,
-    ):
+    if not isinstance(exc, PyMongoError):
+        raise exc
+
+    for mapper in (_map_write_error, _map_operation_failure):
         mapped = mapper(exc, detail)
         if mapped is not None:
             return mapped
@@ -711,8 +786,8 @@ def from_pymongo_error(exc: Exception) -> MongoDBError:
 
 
 def raise_from_pymongo_error(exc: Exception) -> None:
-    """Re-raise a driver error as MongoDBError, keeping the original traceback."""
+    """Re-raise a driver error as MongoDBError with original traceback."""
     if isinstance(exc, MongoDBError):
         raise exc
     driver = find_driver_error(exc) or exc
-    raise from_pymongo_error(driver) from exc
+    raise from_pymongo_error(driver, _for_raise=True) from exc

--- a/src/fastapi_mongo_base/core/errors/i18n.py
+++ b/src/fastapi_mongo_base/core/errors/i18n.py
@@ -1,0 +1,119 @@
+"""Bilingual (en/fa) helpers for HTTP error messages."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from fastapi import Request
+
+SUPPORTED_LOCALES = ("en", "fa")
+DEFAULT_LOCALE = "en"
+FALLBACK_LOCALE = "en"
+
+
+def build_messages(en: str, fa: str | None = None) -> dict[str, str]:
+    """
+    Build a language map with English and optional Persian text.
+
+    Always includes ``en`` for backward compatibility with older clients that
+    only read ``message["en"]``.
+    """
+    messages = {"en": en}
+    if fa:
+        messages["fa"] = fa
+    return messages
+
+
+def normalize_messages(
+    value: str | dict[str, str] | None,
+    *,
+    fallback: str,
+) -> dict[str, str]:
+    """Normalize catalog entries that may be a plain string or a locale map."""
+    if value is None:
+        return build_messages(fallback)
+    if isinstance(value, str):
+        return build_messages(value)
+    if "en" not in value and fallback:
+        return {**value, "en": fallback}
+    return dict(value)
+
+
+def resolve_locale(request: Request | None) -> str:
+    """Resolve ``en`` or ``fa`` from the ``Accept-Language`` header."""
+    if request is None:
+        return DEFAULT_LOCALE
+
+    header = request.headers.get("accept-language", "")
+    if not header:
+        return DEFAULT_LOCALE
+
+    for part in header.split(","):
+        token = part.split(";")[0].strip().lower()
+        if not token:
+            continue
+        if token.startswith("fa"):
+            return "fa"
+        if token.startswith("en"):
+            return "en"
+    return DEFAULT_LOCALE
+
+
+def localized_text(
+    message: dict[str, str],
+    locale: str | None = None,
+) -> str:
+    """Return the best available translation for *locale*."""
+    if not message:
+        return ""
+    locale = locale or DEFAULT_LOCALE
+    if locale in message:
+        return message[locale]
+    if FALLBACK_LOCALE in message:
+        return message[FALLBACK_LOCALE]
+    return next(iter(message.values()))
+
+
+def resolve_detail(
+    *,
+    message: dict[str, str],
+    detail: str | None,
+    locale: str | None = None,
+) -> str:
+    """
+    Pick ``detail`` for the JSON body.
+
+    Explicit ``detail`` wins unless it matches the default English ``message``
+    (auto-generated), in which case the requested locale is used.
+    """
+    locale = locale or DEFAULT_LOCALE
+    localized = localized_text(message, locale)
+    if detail is None:
+        return localized
+    if "en" in message and detail == message["en"]:
+        return localized
+    return detail
+
+
+def http_error_content(
+    request: Request | None,
+    *,
+    message: dict[str, str],
+    error: str,
+    detail: str | None,
+    data: dict[str, object] | None = None,
+) -> dict[str, object]:
+    """
+    Build the standard error JSON payload.
+
+    Response always includes the full ``message`` map (``en`` and ``fa`` when
+    available). ``detail`` follows ``Accept-Language`` when not set explicitly.
+    """
+    locale = resolve_locale(request)
+    return {
+        "message": message,
+        "error": error,
+        "detail": resolve_detail(message=message, detail=detail, locale=locale),
+        **(data or {}),
+    }

--- a/src/fastapi_mongo_base/core/errors/i18n.py
+++ b/src/fastapi_mongo_base/core/errors/i18n.py
@@ -2,10 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from fastapi import Request
+from fastapi import Request
 
 SUPPORTED_LOCALES = ("en", "fa")
 DEFAULT_LOCALE = "en"
@@ -114,6 +111,8 @@ def http_error_content(
     return {
         "message": message,
         "error": error,
-        "detail": resolve_detail(message=message, detail=detail, locale=locale),
+        "detail": resolve_detail(
+            message=message, detail=detail, locale=locale
+        ),
         **(data or {}),
     }

--- a/src/fastapi_mongo_base/core/errors/resource_errors.py
+++ b/src/fastapi_mongo_base/core/errors/resource_errors.py
@@ -23,6 +23,7 @@ class ResourceError(BaseHTTPException):
         message: dict | None = None,
         **kwargs: object,
     ) -> None:
+        """Initialize with optional context fields and message overrides."""
         super().__init__(
             status_code=self.status_code,
             error=self.error_code,
@@ -50,6 +51,7 @@ class ResourceNotFoundError(ResourceError):
         message: dict | None = None,
         **kwargs: object,
     ) -> None:
+        """Initialize with optional context fields and message overrides."""
         if message is None:
             if resource and uid:
                 message = build_messages(
@@ -98,6 +100,7 @@ class ResourceAlreadyExistsError(ResourceError):
         message: dict | None = None,
         **kwargs: object,
     ) -> None:
+        """Initialize with optional context fields and message overrides."""
         if message is None:
             if resource and uid:
                 message = build_messages(
@@ -129,13 +132,52 @@ class ResourceAlreadyExistsError(ResourceError):
         )
 
 
-class ResourceUnauthorizedError(ResourceError):
-    """Raised when the request is not authenticated."""
+class ResourcePaymentRequiredError(ResourceError):
+    """Raised when payment is required to access the resource."""
 
-    status_code = 401
-    error_code = "unauthorized"
-    default_message = "Authentication required"
-    default_message_fa = "برای ادامه، لطفاً وارد حساب کاربری خود شوید."
+    status_code = 402
+    error_code = "payment_required"
+    default_message = "Payment required"
+    default_message_fa = "برای دسترسی به این بخش، پرداخت لازم است."
+
+    def __init__(
+        self,
+        *,
+        resource: str | None = None,
+        reason: str | None = None,
+        detail: str | None = None,
+        message: dict | None = None,
+        **kwargs: object,
+    ) -> None:
+        """Initialize with optional context fields and message overrides."""
+        if message is None:
+            if resource and reason:
+                message = build_messages(
+                    f"Payment required to access this {resource}: {reason}",
+                    f"برای دسترسی به {resource}، پرداخت لازم است: {reason}",
+                )
+            elif resource:
+                message = build_messages(
+                    f"Payment required to access this {resource}",
+                    f"برای دسترسی به {resource}، پرداخت لازم است.",
+                )
+            elif reason:
+                message = build_messages(
+                    f"Payment required: {reason}",
+                    f"پرداخت لازم است: {reason}",
+                )
+            else:
+                message = build_messages(
+                    self.default_message,
+                    self.default_message_fa,
+                )
+        super().__init__(
+            detail=detail,
+            message=message,
+            resource=resource,
+            reason=reason,
+            **kwargs,
+        )
 
 
 class ResourceForbiddenError(ResourceError):
@@ -155,6 +197,7 @@ class ResourceForbiddenError(ResourceError):
         message: dict | None = None,
         **kwargs: object,
     ) -> None:
+        """Initialize with optional context fields and message overrides."""
         if message is None:
             if resource and action:
                 message = build_messages(
@@ -199,6 +242,7 @@ class ResourceConflictError(ResourceError):
         message: dict | None = None,
         **kwargs: object,
     ) -> None:
+        """Initialize with optional context fields and message overrides."""
         if message is None:
             if resource and reason:
                 message = build_messages(
@@ -238,6 +282,7 @@ class ResourceGoneError(ResourceError):
         message: dict | None = None,
         **kwargs: object,
     ) -> None:
+        """Initialize with optional context fields and message overrides."""
         if message is None:
             if resource and uid:
                 message = build_messages(
@@ -263,52 +308,6 @@ class ResourceGoneError(ResourceError):
         )
 
 
-class ResourceInvalidError(ResourceError):
-    """Raised when a resource fails business-rule validation."""
-
-    status_code = 422
-    error_code = "resource_invalid"
-    default_message = "Resource is invalid"
-    default_message_fa = "اطلاعات وارد شده معتبر نیست."
-
-    def __init__(
-        self,
-        *,
-        resource: str | None = None,
-        field: str | None = None,
-        reason: str | None = None,
-        detail: str | None = None,
-        message: dict | None = None,
-        **kwargs: object,
-    ) -> None:
-        if message is None:
-            if resource and field and reason:
-                message = build_messages(
-                    f"Invalid {resource}: {field} - {reason}",
-                    f"در {resource}، مقدار «{field}» معتبر نیست: {reason}",
-                )
-            elif field and reason:
-                message = build_messages(
-                    f"Invalid field '{field}': {reason}",
-                    f"مقدار «{field}» معتبر نیست: {reason}",
-                )
-            elif reason:
-                message = build_messages(reason, reason)
-            else:
-                message = build_messages(
-                    self.default_message,
-                    self.default_message_fa,
-                )
-        super().__init__(
-            detail=detail,
-            message=message,
-            resource=resource,
-            field=field,
-            reason=reason,
-            **kwargs,
-        )
-
-
 class ResourceLockedError(ResourceError):
     """Raised when a resource is locked and cannot be modified."""
 
@@ -326,11 +325,15 @@ class ResourceLockedError(ResourceError):
         message: dict | None = None,
         **kwargs: object,
     ) -> None:
+        """Initialize with optional context fields and message overrides."""
         if message is None:
             if resource and uid:
                 message = build_messages(
                     f"{resource} with id '{uid}' is locked",
-                    f"{resource} با شناسه «{uid}» قفل شده و فعلاً قابل ویرایش نیست.",
+                    (
+                        f"{resource} با شناسه «{uid}» قفل شده و "
+                        "فعلاً قابل ویرایش نیست."
+                    ),
                 )
             elif resource:
                 message = build_messages(

--- a/src/fastapi_mongo_base/core/errors/resource_errors.py
+++ b/src/fastapi_mongo_base/core/errors/resource_errors.py
@@ -1,0 +1,351 @@
+"""HTTP exceptions for API resources (entities, items, etc.)."""
+
+from typing import ClassVar
+
+from fastapi_mongo_base.core.errors.i18n import build_messages
+from fastapi_mongo_base.core.exceptions import BaseHTTPException
+
+
+class ResourceError(BaseHTTPException):
+    """Base exception for resource-related HTTP errors."""
+
+    status_code: ClassVar[int] = 400
+    error_code: ClassVar[str] = "resource_error"
+    default_message: ClassVar[str] = "A resource error occurred"
+    default_message_fa: ClassVar[str | None] = (
+        "مشکلی در پردازش درخواست شما پیش آمد."
+    )
+
+    def __init__(
+        self,
+        *,
+        detail: str | None = None,
+        message: dict | None = None,
+        **kwargs: object,
+    ) -> None:
+        super().__init__(
+            status_code=self.status_code,
+            error=self.error_code,
+            detail=detail,
+            message=message
+            or build_messages(self.default_message, self.default_message_fa),
+            **kwargs,
+        )
+
+
+class ResourceNotFoundError(ResourceError):
+    """Raised when a requested resource does not exist."""
+
+    status_code = 404
+    error_code = "item_not_found"
+    default_message = "Resource not found"
+    default_message_fa = "موردی با این مشخصات پیدا نشد."
+
+    def __init__(
+        self,
+        *,
+        resource: str | None = None,
+        uid: str | None = None,
+        detail: str | None = None,
+        message: dict | None = None,
+        **kwargs: object,
+    ) -> None:
+        if message is None:
+            if resource and uid:
+                message = build_messages(
+                    f"{resource} with id '{uid}' not found",
+                    f"{resource} با شناسه «{uid}» پیدا نشد.",
+                )
+            elif resource:
+                message = build_messages(
+                    f"{resource} not found",
+                    f"{resource} پیدا نشد.",
+                )
+            elif uid:
+                message = build_messages(
+                    f"Resource with id '{uid}' not found",
+                    f"موردی با شناسه «{uid}» پیدا نشد.",
+                )
+            else:
+                message = build_messages(
+                    self.default_message,
+                    self.default_message_fa,
+                )
+        super().__init__(
+            detail=detail,
+            message=message,
+            resource=resource,
+            uid=uid,
+            **kwargs,
+        )
+
+
+class ResourceAlreadyExistsError(ResourceError):
+    """Raised when creating a resource that already exists."""
+
+    status_code = 409
+    error_code = "resource_already_exists"
+    default_message = "Resource already exists"
+    default_message_fa = "این مورد از قبل وجود دارد."
+
+    def __init__(
+        self,
+        *,
+        resource: str | None = None,
+        uid: str | None = None,
+        field: str | None = None,
+        detail: str | None = None,
+        message: dict | None = None,
+        **kwargs: object,
+    ) -> None:
+        if message is None:
+            if resource and uid:
+                message = build_messages(
+                    f"{resource} with id '{uid}' already exists",
+                    f"{resource} با شناسه «{uid}» از قبل ثبت شده است.",
+                )
+            elif resource and field:
+                message = build_messages(
+                    f"{resource} with this {field} already exists",
+                    f"{resource} با این {field} از قبل ثبت شده است.",
+                )
+            elif resource:
+                message = build_messages(
+                    f"{resource} already exists",
+                    f"{resource} از قبل وجود دارد.",
+                )
+            else:
+                message = build_messages(
+                    self.default_message,
+                    self.default_message_fa,
+                )
+        super().__init__(
+            detail=detail,
+            message=message,
+            resource=resource,
+            uid=uid,
+            field=field,
+            **kwargs,
+        )
+
+
+class ResourceUnauthorizedError(ResourceError):
+    """Raised when the request is not authenticated."""
+
+    status_code = 401
+    error_code = "unauthorized"
+    default_message = "Authentication required"
+    default_message_fa = "برای ادامه، لطفاً وارد حساب کاربری خود شوید."
+
+
+class ResourceForbiddenError(ResourceError):
+    """Raised when the caller lacks permission for the resource."""
+
+    status_code = 403
+    error_code = "forbidden"
+    default_message = "You are not authorized to access this resource"
+    default_message_fa = "شما اجازه دسترسی به این بخش را ندارید."
+
+    def __init__(
+        self,
+        *,
+        resource: str | None = None,
+        action: str | None = None,
+        detail: str | None = None,
+        message: dict | None = None,
+        **kwargs: object,
+    ) -> None:
+        if message is None:
+            if resource and action:
+                message = build_messages(
+                    f"You are not authorized to {action} this {resource}",
+                    f"شما اجازه {action} این {resource} را ندارید.",
+                )
+            elif resource:
+                message = build_messages(
+                    f"You are not authorized to access this {resource}",
+                    f"شما اجازه دسترسی به {resource} را ندارید.",
+                )
+            else:
+                message = build_messages(
+                    self.default_message,
+                    self.default_message_fa,
+                )
+        super().__init__(
+            detail=detail,
+            message=message,
+            resource=resource,
+            action=action,
+            **kwargs,
+        )
+
+
+class ResourceConflictError(ResourceError):
+    """Raised when the resource state conflicts with the request."""
+
+    status_code = 409
+    error_code = "resource_conflict"
+    default_message = "The resource is in a conflicting state"
+    default_message_fa = (
+        "به‌دلیل تداخل در وضعیت فعلی، این درخواست قابل انجام نیست."
+    )
+
+    def __init__(
+        self,
+        *,
+        resource: str | None = None,
+        reason: str | None = None,
+        detail: str | None = None,
+        message: dict | None = None,
+        **kwargs: object,
+    ) -> None:
+        if message is None:
+            if resource and reason:
+                message = build_messages(
+                    f"{resource} conflict: {reason}",
+                    f"در {resource} تداخلی پیش آمده است: {reason}",
+                )
+            elif reason:
+                message = build_messages(reason, reason)
+            else:
+                message = build_messages(
+                    self.default_message,
+                    self.default_message_fa,
+                )
+        super().__init__(
+            detail=detail,
+            message=message,
+            resource=resource,
+            reason=reason,
+            **kwargs,
+        )
+
+
+class ResourceGoneError(ResourceError):
+    """Raised when a resource existed but is permanently unavailable."""
+
+    status_code = 410
+    error_code = "resource_gone"
+    default_message = "Resource is no longer available"
+    default_message_fa = "این مورد دیگر در دسترس نیست."
+
+    def __init__(
+        self,
+        *,
+        resource: str | None = None,
+        uid: str | None = None,
+        detail: str | None = None,
+        message: dict | None = None,
+        **kwargs: object,
+    ) -> None:
+        if message is None:
+            if resource and uid:
+                message = build_messages(
+                    f"{resource} with id '{uid}' is no longer available",
+                    f"{resource} با شناسه «{uid}» دیگر در دسترس نیست.",
+                )
+            elif resource:
+                message = build_messages(
+                    f"{resource} is no longer available",
+                    f"{resource} دیگر در دسترس نیست.",
+                )
+            else:
+                message = build_messages(
+                    self.default_message,
+                    self.default_message_fa,
+                )
+        super().__init__(
+            detail=detail,
+            message=message,
+            resource=resource,
+            uid=uid,
+            **kwargs,
+        )
+
+
+class ResourceInvalidError(ResourceError):
+    """Raised when a resource fails business-rule validation."""
+
+    status_code = 422
+    error_code = "resource_invalid"
+    default_message = "Resource is invalid"
+    default_message_fa = "اطلاعات وارد شده معتبر نیست."
+
+    def __init__(
+        self,
+        *,
+        resource: str | None = None,
+        field: str | None = None,
+        reason: str | None = None,
+        detail: str | None = None,
+        message: dict | None = None,
+        **kwargs: object,
+    ) -> None:
+        if message is None:
+            if resource and field and reason:
+                message = build_messages(
+                    f"Invalid {resource}: {field} - {reason}",
+                    f"در {resource}، مقدار «{field}» معتبر نیست: {reason}",
+                )
+            elif field and reason:
+                message = build_messages(
+                    f"Invalid field '{field}': {reason}",
+                    f"مقدار «{field}» معتبر نیست: {reason}",
+                )
+            elif reason:
+                message = build_messages(reason, reason)
+            else:
+                message = build_messages(
+                    self.default_message,
+                    self.default_message_fa,
+                )
+        super().__init__(
+            detail=detail,
+            message=message,
+            resource=resource,
+            field=field,
+            reason=reason,
+            **kwargs,
+        )
+
+
+class ResourceLockedError(ResourceError):
+    """Raised when a resource is locked and cannot be modified."""
+
+    status_code = 423
+    error_code = "resource_locked"
+    default_message = "Resource is locked"
+    default_message_fa = "این مورد در حال حاضر قفل است و قابل تغییر نیست."
+
+    def __init__(
+        self,
+        *,
+        resource: str | None = None,
+        uid: str | None = None,
+        detail: str | None = None,
+        message: dict | None = None,
+        **kwargs: object,
+    ) -> None:
+        if message is None:
+            if resource and uid:
+                message = build_messages(
+                    f"{resource} with id '{uid}' is locked",
+                    f"{resource} با شناسه «{uid}» قفل شده و فعلاً قابل ویرایش نیست.",
+                )
+            elif resource:
+                message = build_messages(
+                    f"{resource} is locked",
+                    f"{resource} قفل شده و فعلاً قابل ویرایش نیست.",
+                )
+            else:
+                message = build_messages(
+                    self.default_message,
+                    self.default_message_fa,
+                )
+        super().__init__(
+            detail=detail,
+            message=message,
+            resource=resource,
+            uid=uid,
+            **kwargs,
+        )

--- a/src/fastapi_mongo_base/core/exceptions.py
+++ b/src/fastapi_mongo_base/core/exceptions.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 import traceback
+from typing import TYPE_CHECKING
 
 import json_advanced
 from fastapi import Request
@@ -15,6 +16,17 @@ from fastapi.exceptions import (
 from fastapi.responses import JSONResponse
 from pydantic import ValidationError
 
+from fastapi_mongo_base.core.errors.i18n import (
+    build_messages,
+    http_error_content,
+    normalize_messages,
+    resolve_detail,
+)
+
+if TYPE_CHECKING:
+    from fastapi_mongo_base.core.errors.db_errors import MongoDBError
+    from fastapi_mongo_base.core.errors.resource_errors import ResourceError
+
 try:
     from usso.integrations.fastapi import (
         EXCEPTION_HANDLERS as usso_exception_handler,  # noqa: N811
@@ -22,7 +34,7 @@ try:
 except ImportError:
     usso_exception_handler = {}
 
-error_messages = {}
+error_messages: dict[str, str | dict[str, str]] = {}
 
 
 class BaseHTTPException(HTTPException):
@@ -59,19 +71,21 @@ class BaseHTTPException(HTTPException):
         """
         self.status_code = status_code
         self.error = error
-        msg: dict = {}
         if message is None:
             if detail:
-                msg["en"] = detail
+                msg = build_messages(detail)
             else:
-                msg["en"] = error_messages.get(error, error)
+                msg = normalize_messages(
+                    error_messages.get(error),
+                    fallback=error if isinstance(error, str) else str(error),
+                )
         else:
-            msg = message
+            msg = dict(message)
 
         self.message = msg
-        self.detail = detail or str(self.message)
+        self.detail = resolve_detail(message=msg, detail=detail)
         self.data = kwargs
-        super().__init__(status_code, detail=detail)
+        super().__init__(status_code, detail=self.detail)
 
 
 def base_http_exception_handler(
@@ -91,12 +105,111 @@ def base_http_exception_handler(
     logging.debug("base_http_exception_handler: %s\n%s", request.url, exc)
     return JSONResponse(
         status_code=exc.status_code,
-        content={
-            "message": exc.message,
-            "error": exc.error,
-            "detail": exc.detail,
-            **exc.data,
-        },
+        content=http_error_content(
+            request,
+            message=exc.message,
+            error=exc.error,
+            detail=exc.detail,
+            data=exc.data,
+        ),
+    )
+
+
+def mongodb_error_handler(
+    request: Request, exc: Exception
+) -> JSONResponse:
+    """
+    Handle MongoDBError subclasses and map driver errors to structured JSON.
+
+    FastAPI matches this handler via MRO for MongoDBError subclasses.
+    pymongo_exception_handler and general_exception_handler delegate here
+    after resolving the exception (including __cause__ / __context__ chains).
+
+    Args:
+        request: FastAPI request object.
+        exc: MongoDBError, pymongo/BSON driver error, or wrapped driver error.
+
+    Returns:
+        JSONResponse with error details and any context from exc.data.
+
+    """
+    from fastapi_mongo_base.core.errors.db_errors import (
+        MongoDBError,
+        from_any_exception,
+        from_pymongo_error,
+    )
+
+    if isinstance(exc, MongoDBError):
+        mongo_exc = exc
+    elif (resolved := from_any_exception(exc)) is not None:
+        mongo_exc = resolved
+    else:
+        mongo_exc = from_pymongo_error(exc)
+
+    log_level = (
+        logging.ERROR if mongo_exc.status_code >= 500 else logging.WARNING
+    )
+    logging.log(
+        log_level,
+        "mongodb_error_handler: %s [%s] %s - %s data=%s",
+        request.url,
+        mongo_exc.error,
+        type(mongo_exc).__name__,
+        mongo_exc.detail,
+        mongo_exc.data,
+        exc_info=(type(exc), exc, exc.__traceback__)
+        if not isinstance(exc, MongoDBError)
+        else False,
+    )
+    return JSONResponse(
+        status_code=mongo_exc.status_code,
+        content=http_error_content(
+            request,
+            message=mongo_exc.message,
+            error=mongo_exc.error,
+            detail=mongo_exc.detail,
+            data=mongo_exc.data,
+        ),
+    )
+
+
+def resource_error_handler(
+    request: Request, exc: "ResourceError"
+) -> JSONResponse:
+    """
+    Handle ResourceError and all subclasses.
+
+    Registered on the ResourceError base class so every resource-specific
+    exception (ResourceNotFoundError, ResourceForbiddenError, etc.) is
+    handled here before the generic BaseHTTPException handler.
+
+    Args:
+        request: FastAPI request object.
+        exc: ResourceError instance or subclass.
+
+    Returns:
+        JSONResponse with error details and any context from exc.data.
+
+    """
+    log_level = logging.ERROR if exc.status_code >= 500 else logging.WARNING
+    logging.log(
+        log_level,
+        "resource_error_handler: %s [%s] %s - %s data=%s",
+        request.url,
+        exc.error,
+        type(exc).__name__,
+        exc.detail,
+        exc.data,
+    )
+    return JSONResponse(
+        status_code=exc.status_code,
+        content=http_error_content(
+            request,
+            message=exc.message,
+            error=exc.error,
+            detail=exc.detail,
+            data=exc.data,
+        ),
     )
 
 
@@ -177,6 +290,9 @@ def general_exception_handler(
     """
     Handle general exceptions and return JSON response.
 
+    Unwraps pymongo/BSON errors hidden in __cause__ / __context__ chains
+    before falling back to a generic 500 response.
+
     Args:
         request: FastAPI request object.
         exc: Exception instance.
@@ -185,22 +301,15 @@ def general_exception_handler(
         JSONResponse with error message.
 
     """
+    from fastapi_mongo_base.core.errors.db_errors import from_any_exception
+
+    mongo_exc = from_any_exception(exc)
+    if mongo_exc is not None:
+        return mongodb_error_handler(request, exc)
+
     traceback_str = "".join(traceback.format_tb(exc.__traceback__))
     logging.error("Exception: %s %s", traceback_str, exc)
     logging.error("Exception on request: %s", request.url)
-
-    try:
-        from pymongo.errors import PyMongoError, ServerSelectionTimeoutError
-
-        if isinstance(exc, ServerSelectionTimeoutError):
-            logging.error("MongoDB connection timeout")
-            os._exit(1)
-
-        if isinstance(exc, PyMongoError):
-            logging.error("MongoDB error")
-            os._exit(1)
-    except ImportError:
-        pass
 
     try:
         from redis.exceptions import RedisError
@@ -217,13 +326,54 @@ def general_exception_handler(
     )
 
 
+from fastapi_mongo_base.core.errors.db_errors import MongoDBError
+from fastapi_mongo_base.core.errors.resource_errors import ResourceError
+
+try:
+    from pymongo.errors import PyMongoError as _PyMongoError
+except ImportError:
+    _PyMongoError = None
+
+
+def pymongo_exception_handler(
+    request: Request, exc: Exception
+) -> JSONResponse:
+    """
+    Handle raw pymongo/BSON driver exceptions matched via MRO.
+
+    Delegates to mongodb_error_handler which maps the driver error to a
+    MongoDBError subclass.
+
+    Args:
+        request: FastAPI request object.
+        exc: PyMongoError or BSON InvalidId from the driver.
+
+    Returns:
+        JSONResponse with mapped database error details.
+
+    """
+    return mongodb_error_handler(request, exc)
+
+
 # A dictionary for dynamic registration
 EXCEPTION_HANDLERS = {
+    MongoDBError: mongodb_error_handler,
+    ResourceError: resource_error_handler,
     BaseHTTPException: base_http_exception_handler,
     ValidationError: pydantic_exception_handler,
     ResponseValidationError: pydantic_exception_handler,
     RequestValidationError: request_validation_exception_handler,
     Exception: general_exception_handler,
 }
+
+if _PyMongoError is not None:
+    EXCEPTION_HANDLERS[_PyMongoError] = pymongo_exception_handler
+
+try:
+    from bson.errors import InvalidId as _BsonInvalidId
+
+    EXCEPTION_HANDLERS[_BsonInvalidId] = pymongo_exception_handler
+except ImportError:
+    pass
 
 EXCEPTION_HANDLERS.update(usso_exception_handler)

--- a/src/fastapi_mongo_base/core/exceptions.py
+++ b/src/fastapi_mongo_base/core/exceptions.py
@@ -4,7 +4,6 @@ import json
 import logging
 import os
 import traceback
-from typing import TYPE_CHECKING
 
 import json_advanced
 from fastapi import Request
@@ -22,10 +21,6 @@ from fastapi_mongo_base.core.errors.i18n import (
     normalize_messages,
     resolve_detail,
 )
-
-if TYPE_CHECKING:
-    from fastapi_mongo_base.core.errors.db_errors import MongoDBError
-    from fastapi_mongo_base.core.errors.resource_errors import ResourceError
 
 try:
     from usso.integrations.fastapi import (
@@ -115,9 +110,7 @@ def base_http_exception_handler(
     )
 
 
-def mongodb_error_handler(
-    request: Request, exc: Exception
-) -> JSONResponse:
+def mongodb_error_handler(request: Request, exc: Exception) -> JSONResponse:
     """
     Handle MongoDBError subclasses and map driver errors to structured JSON.
 
@@ -174,7 +167,7 @@ def mongodb_error_handler(
 
 
 def resource_error_handler(
-    request: Request, exc: "ResourceError"
+    request: Request, exc: BaseHTTPException
 ) -> JSONResponse:
     """
     Handle ResourceError and all subclasses.
@@ -326,15 +319,6 @@ def general_exception_handler(
     )
 
 
-from fastapi_mongo_base.core.errors.db_errors import MongoDBError
-from fastapi_mongo_base.core.errors.resource_errors import ResourceError
-
-try:
-    from pymongo.errors import PyMongoError as _PyMongoError
-except ImportError:
-    _PyMongoError = None
-
-
 def pymongo_exception_handler(
     request: Request, exc: Exception
 ) -> JSONResponse:
@@ -355,25 +339,36 @@ def pymongo_exception_handler(
     return mongodb_error_handler(request, exc)
 
 
-# A dictionary for dynamic registration
-EXCEPTION_HANDLERS = {
-    MongoDBError: mongodb_error_handler,
-    ResourceError: resource_error_handler,
-    BaseHTTPException: base_http_exception_handler,
-    ValidationError: pydantic_exception_handler,
-    ResponseValidationError: pydantic_exception_handler,
-    RequestValidationError: request_validation_exception_handler,
-    Exception: general_exception_handler,
-}
+def _build_exception_handlers() -> dict:
+    from fastapi_mongo_base.core.errors.db_errors import MongoDBError
+    from fastapi_mongo_base.core.errors.resource_errors import ResourceError
 
-if _PyMongoError is not None:
-    EXCEPTION_HANDLERS[_PyMongoError] = pymongo_exception_handler
+    handlers: dict = {
+        MongoDBError: mongodb_error_handler,
+        ResourceError: resource_error_handler,
+        BaseHTTPException: base_http_exception_handler,
+        ValidationError: pydantic_exception_handler,
+        ResponseValidationError: pydantic_exception_handler,
+        RequestValidationError: request_validation_exception_handler,
+        Exception: general_exception_handler,
+    }
 
-try:
-    from bson.errors import InvalidId as _BsonInvalidId
+    try:
+        from pymongo.errors import PyMongoError
 
-    EXCEPTION_HANDLERS[_BsonInvalidId] = pymongo_exception_handler
-except ImportError:
-    pass
+        handlers[PyMongoError] = pymongo_exception_handler
+    except ImportError:
+        pass
 
-EXCEPTION_HANDLERS.update(usso_exception_handler)
+    try:
+        from bson.errors import InvalidId
+
+        handlers[InvalidId] = pymongo_exception_handler
+    except ImportError:
+        pass
+
+    handlers.update(usso_exception_handler)
+    return handlers
+
+
+EXCEPTION_HANDLERS = _build_exception_handlers()

--- a/src/fastapi_mongo_base/schemas.py
+++ b/src/fastapi_mongo_base/schemas.py
@@ -89,7 +89,7 @@ class BaseEntitySchema(BaseModel):
     @property
     def item_url(self) -> str:
         """
-        Get the API URL for this entity item.
+        API URL for this entity item.
 
         Returns:
             Full URL string to the entity endpoint.

--- a/src/fastapi_mongo_base/sql.py
+++ b/src/fastapi_mongo_base/sql.py
@@ -132,7 +132,7 @@ class BaseEntity:
 
     @property
     def item_url(self) -> str:
-        """Get the URL for this item."""
+        """URL for this item."""
         return "/".join([
             f"https://{Settings.root_url}{Settings.base_path}",
             f"{self.__class__.__name__.lower()}s",

--- a/src/fastapi_mongo_base/tasks.py
+++ b/src/fastapi_mongo_base/tasks.py
@@ -173,12 +173,12 @@ class TaskMixin(BaseModel):
 
     @property
     def webhook_exclude_fields(self) -> set[str] | None:
-        """Get fields to exclude from webhook payload."""
+        """Fields to exclude from webhook payload."""
         return None
 
     @property
     def webhook_include_fields(self) -> set[str] | None:
-        """Get fields to include in webhook payload."""
+        """Fields to include in webhook payload."""
         return None
 
     @classmethod
@@ -188,7 +188,7 @@ class TaskMixin(BaseModel):
 
     @property
     def item_webhook_url(self) -> str:
-        """Get the webhook URL for this task item."""
+        """Webhook URL for this task item."""
         return f"{self.item_url}/webhook"  # type: ignore
 
     @property

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,14 +16,8 @@ from .app.server import Settings
 from .app.server import app as fastapi_app
 
 
-@pytest.fixture(scope="session", autouse=True)
-def setup_debugpy() -> None:
-    """
-    Set up debugpy for remote debugging.
-
-    Returns:
-        None.
-    """
+def pytest_configure(config: pytest.Config) -> None:
+    """Start debugpy when remote debugging is enabled."""
     if os.getenv("DEBUGPY", "False").lower() in ("true", "1", "yes"):
         import debugpy  # noqa: T100
 
@@ -65,8 +59,15 @@ async def init_db(mongo_client: object) -> None:
     # pymongo/Beanie versions pass but mongomock does not support.
     orig_list_collection_names = database.delegate.list_collection_names
 
-    def _patched_list_collection_names(filter=None, session=None, **kwargs):
-        return orig_list_collection_names(filter=filter, session=session)
+    def _patched_list_collection_names(
+        query_filter: object | None = None,
+        session: object | None = None,
+        **kwargs: object,
+    ) -> list[str]:
+        return orig_list_collection_names(
+            filter=query_filter,
+            session=session,
+        )
 
     database.delegate.list_collection_names = _patched_list_collection_names
     await init_beanie(
@@ -75,7 +76,7 @@ async def init_db(mongo_client: object) -> None:
     )
 
 
-@pytest_asyncio.fixture(scope="session", autouse=True)
+@pytest_asyncio.fixture(scope="session")
 async def db(mongo_client: object) -> AsyncGenerator[None]:
     """
     Fixture to provide a database for testing.
@@ -95,13 +96,16 @@ async def db(mongo_client: object) -> AsyncGenerator[None]:
 
 
 @pytest_asyncio.fixture(scope="session")
-async def client() -> AsyncGenerator[httpx.AsyncClient]:
+async def client(
+    db: None,
+) -> AsyncGenerator[httpx.AsyncClient]:
     """
     Fixture to provide an AsyncClient for FastAPI app.
 
     Returns:
         AsyncClient.
     """
+    _ = db
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=fastapi_app),
         base_url="http://test.usso.io",

--- a/tests/test_db_init.py
+++ b/tests/test_db_init.py
@@ -12,7 +12,12 @@ from fastapi_mongo_base.core.errors.db_errors import (
 
 
 class _FailingClient:
-    def __init__(self, exc: Exception, *args: object, **kwargs: object) -> None:
+    def __init__(
+        self,
+        exc: Exception,
+        *args: object,
+        **kwargs: object,
+    ) -> None:
         self._exc = exc
 
     async def server_info(self) -> None:
@@ -39,6 +44,7 @@ def _settings(*, exit_on_init_failure: bool) -> Settings:
 async def test_init_mongo_db_raises_connection_timeout_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Init mongo db raises connection timeout error."""
     monkeypatch.setattr(
         "pymongo.AsyncMongoClient",
         _client_factory(ServerSelectionTimeoutError("connection timed out")),
@@ -52,6 +58,7 @@ async def test_init_mongo_db_raises_connection_timeout_error(
 async def test_init_mongo_db_raises_connection_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Init mongo db raises connection error."""
     monkeypatch.setattr(
         "pymongo.AsyncMongoClient",
         _client_factory(ConnectionFailure("could not connect")),
@@ -65,6 +72,7 @@ async def test_init_mongo_db_raises_connection_error(
 async def test_init_mongo_db_exits_on_connection_failure_by_default(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Init mongo db exits on connection failure by default."""
     monkeypatch.setattr(
         "pymongo.AsyncMongoClient",
         _client_factory(ServerSelectionTimeoutError("connection timed out")),

--- a/tests/test_db_init.py
+++ b/tests/test_db_init.py
@@ -1,0 +1,76 @@
+"""Tests for database initialization error handling."""
+
+import pytest
+from pymongo.errors import ConnectionFailure, ServerSelectionTimeoutError
+
+from fastapi_mongo_base.core import db
+from fastapi_mongo_base.core.config import Settings
+from fastapi_mongo_base.core.errors.db_errors import (
+    MongoDBConnectionError,
+    MongoDBConnectionTimeoutError,
+)
+
+
+class _FailingClient:
+    def __init__(self, exc: Exception, *args: object, **kwargs: object) -> None:
+        self._exc = exc
+
+    async def server_info(self) -> None:
+        raise self._exc
+
+    def get_database(self, _name: str) -> object:
+        return object()
+
+
+def _client_factory(exc: Exception) -> type:
+    def _factory(*args: object, **kwargs: object) -> _FailingClient:
+        return _FailingClient(exc, *args, **kwargs)
+
+    return _factory
+
+
+def _settings(*, exit_on_init_failure: bool) -> Settings:
+    settings = Settings()
+    settings.exit_on_init_failure = exit_on_init_failure
+    return settings
+
+
+@pytest.mark.asyncio
+async def test_init_mongo_db_raises_connection_timeout_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "pymongo.AsyncMongoClient",
+        _client_factory(ServerSelectionTimeoutError("connection timed out")),
+    )
+
+    with pytest.raises(MongoDBConnectionTimeoutError):
+        await db.init_mongo_db(_settings(exit_on_init_failure=False))
+
+
+@pytest.mark.asyncio
+async def test_init_mongo_db_raises_connection_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "pymongo.AsyncMongoClient",
+        _client_factory(ConnectionFailure("could not connect")),
+    )
+
+    with pytest.raises(MongoDBConnectionError):
+        await db.init_mongo_db(_settings(exit_on_init_failure=False))
+
+
+@pytest.mark.asyncio
+async def test_init_mongo_db_exits_on_connection_failure_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "pymongo.AsyncMongoClient",
+        _client_factory(ServerSelectionTimeoutError("connection timed out")),
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        await db.init_mongo_db(_settings(exit_on_init_failure=True))
+
+    assert exc_info.value.code == 1

--- a/tests/test_i18n_errors.py
+++ b/tests/test_i18n_errors.py
@@ -1,0 +1,133 @@
+"""Tests for bilingual error message helpers."""
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from fastapi_mongo_base.core.app_factory import setup_exception_handlers
+from fastapi_mongo_base.core.errors.i18n import (
+    build_messages,
+    http_error_content,
+    localized_text,
+    normalize_messages,
+    resolve_locale,
+)
+from fastapi_mongo_base.core.errors.resource_errors import ResourceNotFoundError
+from fastapi_mongo_base.core.exceptions import BaseHTTPException, error_messages
+
+
+def test_build_messages_always_includes_en() -> None:
+    assert build_messages("Hello") == {"en": "Hello"}
+    assert build_messages("Hello", "سلام") == {"en": "Hello", "fa": "سلام"}
+
+
+def test_normalize_messages_backward_compatible_string() -> None:
+    assert normalize_messages("Legacy text", fallback="fb") == {
+        "en": "Legacy text",
+    }
+
+
+def test_normalize_messages_dict_passthrough() -> None:
+    messages = {"en": "Hi", "fa": "سلام"}
+    assert normalize_messages(messages, fallback="fb") == messages
+
+
+def test_resolve_locale_from_accept_language() -> None:
+    class _Req:
+        headers = {"accept-language": "fa-IR,fa;q=0.9,en;q=0.8"}
+
+    assert resolve_locale(_Req()) == "fa"  # type: ignore[arg-type]
+
+    class _ReqEn:
+        headers = {"accept-language": "en-US,en;q=0.9"}
+
+    assert resolve_locale(_ReqEn()) == "en"  # type: ignore[arg-type]
+
+
+def test_localized_text_falls_back_to_en() -> None:
+    assert localized_text({"en": "Hello"}, "fa") == "Hello"
+
+
+def test_http_error_content_localizes_detail() -> None:
+    class _Req:
+        headers = {"accept-language": "fa"}
+
+    content = http_error_content(
+        _Req(),  # type: ignore[arg-type]
+        message={"en": "Not found", "fa": "یافت نشد"},
+        error="item_not_found",
+        detail=None,
+        data={"uid": "1"},
+    )
+    assert content["message"] == {"en": "Not found", "fa": "یافت نشد"}
+    assert content["detail"] == "یافت نشد"
+    assert content["uid"] == "1"
+
+
+def test_base_http_exception_legacy_error_messages_string() -> None:
+    error_messages["legacy_code"] = "Legacy English"
+    exc = BaseHTTPException(status_code=400, error="legacy_code")
+    assert exc.message == {"en": "Legacy English"}
+    assert exc.detail == "Legacy English"
+    error_messages.pop("legacy_code")
+
+
+def test_base_http_exception_bilingual_catalog_entry() -> None:
+    error_messages["bilingual_code"] = {
+        "en": "English",
+        "fa": "فارسی",
+    }
+    exc = BaseHTTPException(status_code=400, error="bilingual_code")
+    assert exc.message["en"] == "English"
+    assert exc.message["fa"] == "فارسی"
+    error_messages.pop("bilingual_code")
+
+
+@pytest.fixture
+def locale_app() -> FastAPI:
+    app = FastAPI()
+    setup_exception_handlers(app=app)
+
+    @app.get("/not-found")
+    async def not_found() -> None:
+        raise ResourceNotFoundError(resource="User", uid="abc123")
+
+    return app
+
+
+@pytest.mark.asyncio
+async def test_accept_language_fa_localizes_detail(locale_app: FastAPI) -> None:
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(
+            app=locale_app,
+            raise_app_exceptions=False,
+        ),
+        base_url="http://test",
+    ) as client:
+        response = await client.get(
+            "/not-found",
+            headers={"Accept-Language": "fa-IR,fa;q=0.9"},
+        )
+
+    body = response.json()
+    assert response.status_code == 404
+    assert body["message"]["en"] == "User with id 'abc123' not found"
+    assert body["message"]["fa"] == "User با شناسه «abc123» پیدا نشد."
+    assert body["detail"] == body["message"]["fa"]
+
+
+@pytest.mark.asyncio
+async def test_without_accept_language_defaults_to_en_detail(
+    locale_app: FastAPI,
+) -> None:
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(
+            app=locale_app,
+            raise_app_exceptions=False,
+        ),
+        base_url="http://test",
+    ) as client:
+        response = await client.get("/not-found")
+
+    body = response.json()
+    assert body["detail"] == body["message"]["en"]

--- a/tests/test_i18n_errors.py
+++ b/tests/test_i18n_errors.py
@@ -1,5 +1,7 @@
 """Tests for bilingual error message helpers."""
 
+from types import SimpleNamespace
+
 import httpx
 import pytest
 from fastapi import FastAPI
@@ -12,48 +14,55 @@ from fastapi_mongo_base.core.errors.i18n import (
     normalize_messages,
     resolve_locale,
 )
-from fastapi_mongo_base.core.errors.resource_errors import ResourceNotFoundError
-from fastapi_mongo_base.core.exceptions import BaseHTTPException, error_messages
+from fastapi_mongo_base.core.errors.resource_errors import (
+    ResourceNotFoundError,
+)
+from fastapi_mongo_base.core.exceptions import (
+    BaseHTTPException,
+    error_messages,
+)
 
 
 def test_build_messages_always_includes_en() -> None:
+    """Build messages always includes en."""
     assert build_messages("Hello") == {"en": "Hello"}
     assert build_messages("Hello", "سلام") == {"en": "Hello", "fa": "سلام"}
 
 
 def test_normalize_messages_backward_compatible_string() -> None:
+    """Normalize messages backward compatible string."""
     assert normalize_messages("Legacy text", fallback="fb") == {
         "en": "Legacy text",
     }
 
 
 def test_normalize_messages_dict_passthrough() -> None:
+    """Normalize messages dict passthrough."""
     messages = {"en": "Hi", "fa": "سلام"}
     assert normalize_messages(messages, fallback="fb") == messages
 
 
 def test_resolve_locale_from_accept_language() -> None:
-    class _Req:
-        headers = {"accept-language": "fa-IR,fa;q=0.9,en;q=0.8"}
+    """Resolve locale from accept language."""
+    fa_request = SimpleNamespace(
+        headers={"accept-language": "fa-IR,fa;q=0.9,en;q=0.8"},
+    )
+    assert resolve_locale(fa_request) == "fa"  # type: ignore[arg-type]
 
-    assert resolve_locale(_Req()) == "fa"  # type: ignore[arg-type]
-
-    class _ReqEn:
-        headers = {"accept-language": "en-US,en;q=0.9"}
-
-    assert resolve_locale(_ReqEn()) == "en"  # type: ignore[arg-type]
+    en_request = SimpleNamespace(headers={"accept-language": "en-US,en;q=0.9"})
+    assert resolve_locale(en_request) == "en"  # type: ignore[arg-type]
 
 
 def test_localized_text_falls_back_to_en() -> None:
+    """Localized text falls back to en."""
     assert localized_text({"en": "Hello"}, "fa") == "Hello"
 
 
 def test_http_error_content_localizes_detail() -> None:
-    class _Req:
-        headers = {"accept-language": "fa"}
-
+    """Http error content localizes detail."""
+    fa_request = SimpleNamespace(headers={"accept-language": "fa"})
     content = http_error_content(
-        _Req(),  # type: ignore[arg-type]
+        fa_request,  # type: ignore[arg-type]
         message={"en": "Not found", "fa": "یافت نشد"},
         error="item_not_found",
         detail=None,
@@ -65,6 +74,7 @@ def test_http_error_content_localizes_detail() -> None:
 
 
 def test_base_http_exception_legacy_error_messages_string() -> None:
+    """Base http exception legacy error messages string."""
     error_messages["legacy_code"] = "Legacy English"
     exc = BaseHTTPException(status_code=400, error="legacy_code")
     assert exc.message == {"en": "Legacy English"}
@@ -73,6 +83,7 @@ def test_base_http_exception_legacy_error_messages_string() -> None:
 
 
 def test_base_http_exception_bilingual_catalog_entry() -> None:
+    """Base http exception bilingual catalog entry."""
     error_messages["bilingual_code"] = {
         "en": "English",
         "fa": "فارسی",
@@ -85,6 +96,7 @@ def test_base_http_exception_bilingual_catalog_entry() -> None:
 
 @pytest.fixture
 def locale_app() -> FastAPI:
+    """FastAPI app with resource error handlers registered."""
     app = FastAPI()
     setup_exception_handlers(app=app)
 
@@ -96,7 +108,10 @@ def locale_app() -> FastAPI:
 
 
 @pytest.mark.asyncio
-async def test_accept_language_fa_localizes_detail(locale_app: FastAPI) -> None:
+async def test_accept_language_fa_localizes_detail(
+    locale_app: FastAPI,
+) -> None:
+    """Accept language fa localizes detail."""
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(
             app=locale_app,
@@ -120,6 +135,7 @@ async def test_accept_language_fa_localizes_detail(locale_app: FastAPI) -> None:
 async def test_without_accept_language_defaults_to_en_detail(
     locale_app: FastAPI,
 ) -> None:
+    """Without accept language defaults to en detail."""
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(
             app=locale_app,

--- a/tests/test_mongo_exceptions.py
+++ b/tests/test_mongo_exceptions.py
@@ -13,6 +13,7 @@ from fastapi_mongo_base.core.app_factory import setup_exception_handlers
 
 @pytest.fixture
 def mongo_error_app() -> FastAPI:
+    """FastAPI app with MongoDB error handlers registered."""
     app = FastAPI()
     setup_exception_handlers(app=app)
 
@@ -27,12 +28,15 @@ def mongo_error_app() -> FastAPI:
             },
         )
 
+    def _duplicate_key_error() -> DuplicateKeyError:
+        return DuplicateKeyError("E11000 duplicate key error", 11000, {})
+
+    def _raise_wrapped_duplicate_key() -> None:
+        raise RuntimeError("insert failed") from _duplicate_key_error()
+
     @app.get("/wrapped")
     async def wrapped() -> None:
-        try:
-            raise DuplicateKeyError("E11000 duplicate key error", 11000, {})
-        except DuplicateKeyError as err:
-            raise RuntimeError("insert failed") from err
+        _raise_wrapped_duplicate_key()
 
     @app.get("/timeout")
     async def timeout() -> None:
@@ -53,6 +57,7 @@ def mongo_error_app() -> FastAPI:
 async def mongo_error_client(
     mongo_error_app: FastAPI,
 ) -> AsyncIterator[httpx.AsyncClient]:
+    """HTTP client wired to the MongoDB error test app."""
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(
             app=mongo_error_app,
@@ -67,6 +72,7 @@ async def mongo_error_client(
 async def test_duplicate_key_auto_mapped(
     mongo_error_client: httpx.AsyncClient,
 ) -> None:
+    """Duplicate key auto mapped."""
     response = await mongo_error_client.get("/duplicate-key")
 
     assert response.status_code == 409
@@ -81,6 +87,7 @@ async def test_duplicate_key_auto_mapped(
 async def test_wrapped_duplicate_key_auto_mapped(
     mongo_error_client: httpx.AsyncClient,
 ) -> None:
+    """Wrapped duplicate key auto mapped."""
     response = await mongo_error_client.get("/wrapped")
 
     assert response.status_code == 409
@@ -91,6 +98,7 @@ async def test_wrapped_duplicate_key_auto_mapped(
 async def test_connection_timeout_auto_mapped(
     mongo_error_client: httpx.AsyncClient,
 ) -> None:
+    """Connection timeout auto mapped."""
     response = await mongo_error_client.get("/timeout")
 
     assert response.status_code == 503
@@ -101,6 +109,7 @@ async def test_connection_timeout_auto_mapped(
 async def test_invalid_object_id_auto_mapped(
     mongo_error_client: httpx.AsyncClient,
 ) -> None:
+    """Invalid object id auto mapped."""
     response = await mongo_error_client.get("/invalid-id")
 
     assert response.status_code == 400
@@ -111,6 +120,7 @@ async def test_invalid_object_id_auto_mapped(
 async def test_unrelated_exception_stays_generic(
     mongo_error_client: httpx.AsyncClient,
 ) -> None:
+    """Unrelated exception stays generic."""
     response = await mongo_error_client.get("/other")
 
     assert response.status_code == 500

--- a/tests/test_mongo_exceptions.py
+++ b/tests/test_mongo_exceptions.py
@@ -1,0 +1,117 @@
+"""Tests for automatic MongoDB error handling."""
+
+from collections.abc import AsyncIterator
+
+import httpx
+import pytest
+from bson.errors import InvalidId
+from fastapi import FastAPI
+from pymongo.errors import DuplicateKeyError, ServerSelectionTimeoutError
+
+from fastapi_mongo_base.core.app_factory import setup_exception_handlers
+
+
+@pytest.fixture
+def mongo_error_app() -> FastAPI:
+    app = FastAPI()
+    setup_exception_handlers(app=app)
+
+    @app.get("/duplicate-key")
+    async def duplicate_key() -> None:
+        raise DuplicateKeyError(
+            "E11000 duplicate key error",
+            11000,
+            {
+                "keyPattern": {"email": 1},
+                "keyValue": {"email": "a@b.c"},
+            },
+        )
+
+    @app.get("/wrapped")
+    async def wrapped() -> None:
+        try:
+            raise DuplicateKeyError("E11000 duplicate key error", 11000, {})
+        except DuplicateKeyError as err:
+            raise RuntimeError("insert failed") from err
+
+    @app.get("/timeout")
+    async def timeout() -> None:
+        raise ServerSelectionTimeoutError("connection timed out")
+
+    @app.get("/invalid-id")
+    async def invalid_id() -> None:
+        raise InvalidId("not-a-valid-objectid")
+
+    @app.get("/other")
+    async def other() -> None:
+        raise ValueError("unrelated")
+
+    return app
+
+
+@pytest.fixture
+async def mongo_error_client(
+    mongo_error_app: FastAPI,
+) -> AsyncIterator[httpx.AsyncClient]:
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(
+            app=mongo_error_app,
+            raise_app_exceptions=False,
+        ),
+        base_url="http://test",
+    ) as client:
+        yield client
+
+
+@pytest.mark.asyncio
+async def test_duplicate_key_auto_mapped(
+    mongo_error_client: httpx.AsyncClient,
+) -> None:
+    response = await mongo_error_client.get("/duplicate-key")
+
+    assert response.status_code == 409
+    body = response.json()
+    assert body["error"] == "duplicate_key"
+    assert body["field"] == "email"
+    assert body["value"] == "a@b.c"
+    assert "fa" in body["message"]
+
+
+@pytest.mark.asyncio
+async def test_wrapped_duplicate_key_auto_mapped(
+    mongo_error_client: httpx.AsyncClient,
+) -> None:
+    response = await mongo_error_client.get("/wrapped")
+
+    assert response.status_code == 409
+    assert response.json()["error"] == "duplicate_key"
+
+
+@pytest.mark.asyncio
+async def test_connection_timeout_auto_mapped(
+    mongo_error_client: httpx.AsyncClient,
+) -> None:
+    response = await mongo_error_client.get("/timeout")
+
+    assert response.status_code == 503
+    assert response.json()["error"] == "mongodb_connection_timeout"
+
+
+@pytest.mark.asyncio
+async def test_invalid_object_id_auto_mapped(
+    mongo_error_client: httpx.AsyncClient,
+) -> None:
+    response = await mongo_error_client.get("/invalid-id")
+
+    assert response.status_code == 400
+    assert response.json()["error"] == "invalid_object_id"
+
+
+@pytest.mark.asyncio
+async def test_unrelated_exception_stays_generic(
+    mongo_error_client: httpx.AsyncClient,
+) -> None:
+    response = await mongo_error_client.get("/other")
+
+    assert response.status_code == 500
+    assert response.json()["error"] == "Exception"

--- a/tests/test_resource_exceptions.py
+++ b/tests/test_resource_exceptions.py
@@ -13,10 +13,9 @@ from fastapi_mongo_base.core.errors.resource_errors import (
     ResourceError,
     ResourceForbiddenError,
     ResourceGoneError,
-    ResourceInvalidError,
     ResourceLockedError,
     ResourceNotFoundError,
-    ResourceUnauthorizedError,
+    ResourcePaymentRequiredError,
 )
 
 ResourceCase = tuple[
@@ -45,19 +44,19 @@ RESOURCE_ERROR_CASES: list[ResourceCase] = [
     ),
     (
         "already-exists",
-        lambda: ResourceAlreadyExistsError(
-            resource="User", field="email"
-        ),
+        lambda: ResourceAlreadyExistsError(resource="User", field="email"),
         409,
         "resource_already_exists",
         {"resource": "User", "uid": None, "field": "email"},
     ),
     (
-        "unauthorized",
-        lambda: ResourceUnauthorizedError(),
-        401,
-        "unauthorized",
-        {},
+        "payment-required",
+        lambda: ResourcePaymentRequiredError(
+            resource="Subscription", reason="plan expired"
+        ),
+        402,
+        "payment_required",
+        {"resource": "Subscription", "reason": "plan expired"},
     ),
     (
         "forbidden",
@@ -83,21 +82,6 @@ RESOURCE_ERROR_CASES: list[ResourceCase] = [
         {"resource": "Post", "uid": "post-1"},
     ),
     (
-        "invalid",
-        lambda: ResourceInvalidError(
-            resource="User",
-            field="age",
-            reason="must be positive",
-        ),
-        422,
-        "resource_invalid",
-        {
-            "resource": "User",
-            "field": "age",
-            "reason": "must be positive",
-        },
-    ),
-    (
         "locked",
         lambda: ResourceLockedError(resource="Document", uid="doc-9"),
         423,
@@ -109,6 +93,7 @@ RESOURCE_ERROR_CASES: list[ResourceCase] = [
 
 @pytest.fixture
 def resource_error_app() -> FastAPI:
+    """FastAPI app exposing one route per resource error case."""
     app = FastAPI()
     setup_exception_handlers(app=app)
 
@@ -117,7 +102,7 @@ def resource_error_app() -> FastAPI:
         def make_endpoint(
             exc_factory: Callable[[], Exception] = factory,
         ) -> Callable[[], None]:
-            async def endpoint() -> None:
+            def endpoint() -> None:
                 raise exc_factory()
 
             return endpoint
@@ -135,6 +120,7 @@ def resource_error_app() -> FastAPI:
 async def resource_error_client(
     resource_error_app: FastAPI,
 ) -> AsyncIterator[httpx.AsyncClient]:
+    """HTTP client wired to the resource error test app."""
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(
             app=resource_error_app,
@@ -159,6 +145,7 @@ async def test_resource_error_handler_returns_structured_json(
     error_code: str,
     extra_fields: dict[str, object],
 ) -> None:
+    """Resource error handler returns structured json."""
     _ = factory
     response = await resource_error_client.get(f"/resource/{path}")
 
@@ -177,6 +164,7 @@ async def test_resource_error_handler_returns_structured_json(
 async def test_resource_not_found_message(
     resource_error_client: httpx.AsyncClient,
 ) -> None:
+    """Resource not found message."""
     response = await resource_error_client.get("/resource/not-found")
 
     body = response.json()
@@ -188,6 +176,7 @@ async def test_resource_not_found_message(
 async def test_resource_forbidden_message(
     resource_error_client: httpx.AsyncClient,
 ) -> None:
+    """Resource forbidden message."""
     response = await resource_error_client.get("/resource/forbidden")
 
     body = response.json()

--- a/tests/test_resource_exceptions.py
+++ b/tests/test_resource_exceptions.py
@@ -1,0 +1,197 @@
+"""Tests for ResourceError exception handling via FastAPI handlers."""
+
+from collections.abc import AsyncIterator, Callable
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from fastapi_mongo_base.core.app_factory import setup_exception_handlers
+from fastapi_mongo_base.core.errors.resource_errors import (
+    ResourceAlreadyExistsError,
+    ResourceConflictError,
+    ResourceError,
+    ResourceForbiddenError,
+    ResourceGoneError,
+    ResourceInvalidError,
+    ResourceLockedError,
+    ResourceNotFoundError,
+    ResourceUnauthorizedError,
+)
+
+ResourceCase = tuple[
+    str,
+    Callable[[], Exception],
+    int,
+    str,
+    dict[str, object],
+]
+
+
+RESOURCE_ERROR_CASES: list[ResourceCase] = [
+    (
+        "base",
+        lambda: ResourceError(detail="generic resource failure"),
+        400,
+        "resource_error",
+        {},
+    ),
+    (
+        "not-found",
+        lambda: ResourceNotFoundError(resource="User", uid="abc123"),
+        404,
+        "item_not_found",
+        {"resource": "User", "uid": "abc123"},
+    ),
+    (
+        "already-exists",
+        lambda: ResourceAlreadyExistsError(
+            resource="User", field="email"
+        ),
+        409,
+        "resource_already_exists",
+        {"resource": "User", "uid": None, "field": "email"},
+    ),
+    (
+        "unauthorized",
+        lambda: ResourceUnauthorizedError(),
+        401,
+        "unauthorized",
+        {},
+    ),
+    (
+        "forbidden",
+        lambda: ResourceForbiddenError(resource="User", action="delete"),
+        403,
+        "forbidden",
+        {"resource": "User", "action": "delete"},
+    ),
+    (
+        "conflict",
+        lambda: ResourceConflictError(
+            resource="Order", reason="already shipped"
+        ),
+        409,
+        "resource_conflict",
+        {"resource": "Order", "reason": "already shipped"},
+    ),
+    (
+        "gone",
+        lambda: ResourceGoneError(resource="Post", uid="post-1"),
+        410,
+        "resource_gone",
+        {"resource": "Post", "uid": "post-1"},
+    ),
+    (
+        "invalid",
+        lambda: ResourceInvalidError(
+            resource="User",
+            field="age",
+            reason="must be positive",
+        ),
+        422,
+        "resource_invalid",
+        {
+            "resource": "User",
+            "field": "age",
+            "reason": "must be positive",
+        },
+    ),
+    (
+        "locked",
+        lambda: ResourceLockedError(resource="Document", uid="doc-9"),
+        423,
+        "resource_locked",
+        {"resource": "Document", "uid": "doc-9"},
+    ),
+]
+
+
+@pytest.fixture
+def resource_error_app() -> FastAPI:
+    app = FastAPI()
+    setup_exception_handlers(app=app)
+
+    for path, factory, *_ in RESOURCE_ERROR_CASES:
+
+        def make_endpoint(
+            exc_factory: Callable[[], Exception] = factory,
+        ) -> Callable[[], None]:
+            async def endpoint() -> None:
+                raise exc_factory()
+
+            return endpoint
+
+        app.add_api_route(
+            f"/resource/{path}",
+            make_endpoint(),
+            methods=["GET"],
+        )
+
+    return app
+
+
+@pytest.fixture
+async def resource_error_client(
+    resource_error_app: FastAPI,
+) -> AsyncIterator[httpx.AsyncClient]:
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(
+            app=resource_error_app,
+            raise_app_exceptions=False,
+        ),
+        base_url="http://test",
+    ) as client:
+        yield client
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("path", "factory", "status_code", "error_code", "extra_fields"),
+    RESOURCE_ERROR_CASES,
+    ids=[case[0] for case in RESOURCE_ERROR_CASES],
+)
+async def test_resource_error_handler_returns_structured_json(
+    resource_error_client: httpx.AsyncClient,
+    path: str,
+    factory: Callable[[], Exception],
+    status_code: int,
+    error_code: str,
+    extra_fields: dict[str, object],
+) -> None:
+    _ = factory
+    response = await resource_error_client.get(f"/resource/{path}")
+
+    assert response.status_code == status_code
+    body = response.json()
+    assert body["error"] == error_code
+    assert "message" in body
+    assert "en" in body["message"]
+    assert "fa" in body["message"]
+    assert "detail" in body
+    for key, value in extra_fields.items():
+        assert body[key] == value
+
+
+@pytest.mark.asyncio
+async def test_resource_not_found_message(
+    resource_error_client: httpx.AsyncClient,
+) -> None:
+    response = await resource_error_client.get("/resource/not-found")
+
+    body = response.json()
+    assert body["message"]["en"] == "User with id 'abc123' not found"
+    assert "fa" in body["message"]
+
+
+@pytest.mark.asyncio
+async def test_resource_forbidden_message(
+    resource_error_client: httpx.AsyncClient,
+) -> None:
+    response = await resource_error_client.get("/resource/forbidden")
+
+    body = response.json()
+    assert body["message"]["en"] == (
+        "You are not authorized to delete this User"
+    )
+    assert body["message"]["fa"] == "شما اجازه delete این User را ندارید."


### PR DESCRIPTION
## Summary

This PR error handling across the library: structured MongoDB and resource exceptions with bilingual (en/fa) messages, automatic PyMongo/BSON error mapping in FastAPI handlers, and a configurable `exit_on_init_failure` setting that controls whether MongoDB/Redis init failures exit the process or raise typed errors.

### MongoDB error handling

- Add `core/errors/db_errors.py` with a `MongoDBError` hierarchy covering connection failures, timeouts, document CRUD issues, duplicate keys, validation, transactions, and authorization errors.
- Add `from_pymongo_error`, `from_any_exception`, and `find_driver_error` to map PyMongo/BSON exceptions (including wrapped errors in `__cause__` / `__context__` chains) to the appropriate `MongoDBError` subclass.
- Add `mongodb_error_handler` and `pymongo_exception_handler`; register handlers for `MongoDBError`, `PyMongoError`, and `InvalidId`.
- Update `general_exception_handler` to unwrap and delegate driver errors before falling back to a generic 500 response.

### Resource error handling

- Add `core/errors/resource_errors.py` with a `ResourceError` hierarchy: `ResourceNotFoundError`, `ResourceAlreadyExistsError`, `ResourceUnauthorizedError`, `ResourceForbiddenError`, `ResourceConflictError`, `ResourceGoneError`, `ResourceInvalidError`, and `ResourceLockedError`.
- Add `resource_error_handler`, registered on the `ResourceError` base class so all subclasses are handled consistently.

### Bilingual (en/fa) messages

- Add `core/errors/i18n.py` with `build_messages`, `resolve_locale`, `localized_text`, and `http_error_content` helpers.
- Update `BaseHTTPException` to support bilingual `message` dicts (`en` / `fa`) with `Accept-Language` resolution in API responses.
- All new exception classes ship with English and Persian default messages.

### Configurable init failure behavior

- Add `exit_on_init_failure` setting to `Settings` (env: `EXIT_ON_INIT_FAILURE`, default: `true`).
- When `true` (default): MongoDB and Redis init failures call `SystemExit(1)` — suitable for Docker/Kubernetes so the container restarts until dependencies are available.
- When `false`: MongoDB init failures raise typed exceptions (`MongoDBConnectionError`, `MongoDBConnectionTimeoutError`, etc.) via `raise_from_pymongo_error`.
- Add `_fail_mongo_init` helper in `db.py` to centralize this branching logic.

## Changed files

| File | Change |
|------|--------|
| `core/errors/db_errors.py` | New — MongoDB exception types and driver error mapping |
| `core/errors/resource_errors.py` | New — Resource exception types |
| `core/errors/i18n.py` | New — Bilingual message helpers |
| `core/exceptions.py` | MongoDB/resource handlers, pymongo unwrapping, i18n integration |
| `core/config.py` | Add `exit_on_init_failure` setting |
| `core/db.py` | Configurable init failure behavior for MongoDB and Redis |
| `tests/test_mongo_exceptions.py` | New — driver error mapping and handler tests |
| `tests/test_resource_exceptions.py` | New — resource error handler tests |
| `tests/test_i18n_errors.py` | New — locale and message format tests |
| `tests/test_db_init.py` | New — init failure behavior tests |

## Test plan

- [x] `pytest tests/test_mongo_exceptions.py` — duplicate key, connection timeout, invalid ObjectId, wrapped driver errors, unrelated exceptions
- [x] `pytest tests/test_resource_exceptions.py` — all `ResourceError` subclasses return correct status codes, error codes, and context data
- [x] `pytest tests/test_i18n_errors.py` — `build_messages`, `Accept-Language` resolution, backward-compatible string messages
- [x] `pytest tests/test_db_init.py` — typed errors when `exit_on_init_failure=false`, `SystemExit(1)` when `exit_on_init_failure=true`
- [ ] Verify default Docker/K8s startup still exits and restarts on MongoDB unavailability
- [ ] Confirm API clients receive localized `detail` when sending `Accept-Language: fa`