### PR TITLE
Refactor bilingual message handling in i18n module. Update build_mess…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fastapi-mongo-base"
-version = "1.2.0"
+version = "1.2.1"
 description = "A simple boilerplate application, including models and schemas and abstract router, for FastAPI with MongoDB"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/fastapi_mongo_base/core/errors/i18n.py
+++ b/src/fastapi_mongo_base/core/errors/i18n.py
@@ -11,15 +11,12 @@ FALLBACK_LOCALE = "en"
 
 def build_messages(en: str, fa: str | None = None) -> dict[str, str]:
     """
-    Build a language map with English and optional Persian text.
+    Build a bilingual language map with English and Persian text.
 
-    Always includes ``en`` for backward compatibility with older clients that
-    only read ``message["en"]``.
+    Always includes both ``en`` and ``fa``. When Persian text is omitted,
+    ``fa`` falls back to the English string.
     """
-    messages = {"en": en}
-    if fa:
-        messages["fa"] = fa
-    return messages
+    return {"en": en, "fa": fa if fa is not None else en}
 
 
 def normalize_messages(
@@ -32,9 +29,12 @@ def normalize_messages(
         return build_messages(fallback)
     if isinstance(value, str):
         return build_messages(value)
-    if "en" not in value and fallback:
-        return {**value, "en": fallback}
-    return dict(value)
+    messages = dict(value)
+    if "en" not in messages and fallback:
+        messages["en"] = fallback
+    if "fa" not in messages and "en" in messages:
+        messages["fa"] = messages["en"]
+    return messages
 
 
 def resolve_locale(request: Request | None) -> str:

--- a/tests/test_i18n_errors.py
+++ b/tests/test_i18n_errors.py
@@ -23,9 +23,9 @@ from fastapi_mongo_base.core.exceptions import (
 )
 
 
-def test_build_messages_always_includes_en() -> None:
-    """Build messages always includes en."""
-    assert build_messages("Hello") == {"en": "Hello"}
+def test_build_messages_always_includes_en_and_fa() -> None:
+    """Build messages always includes en and fa."""
+    assert build_messages("Hello") == {"en": "Hello", "fa": "Hello"}
     assert build_messages("Hello", "سلام") == {"en": "Hello", "fa": "سلام"}
 
 
@@ -33,6 +33,7 @@ def test_normalize_messages_backward_compatible_string() -> None:
     """Normalize messages backward compatible string."""
     assert normalize_messages("Legacy text", fallback="fb") == {
         "en": "Legacy text",
+        "fa": "Legacy text",
     }
 
 
@@ -77,7 +78,7 @@ def test_base_http_exception_legacy_error_messages_string() -> None:
     """Base http exception legacy error messages string."""
     error_messages["legacy_code"] = "Legacy English"
     exc = BaseHTTPException(status_code=400, error="legacy_code")
-    assert exc.message == {"en": "Legacy English"}
+    assert exc.message == {"en": "Legacy English", "fa": "Legacy English"}
     assert exc.detail == "Legacy English"
     error_messages.pop("legacy_code")
 


### PR DESCRIPTION
…ages function to always include both English and Persian text, enhancing backward compatibility. Adjust tests to reflect changes in message structure.